### PR TITLE
Andrewmwells/fix corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
       - name: cargo test
         working-directory: ./CedarJavaFFI
         run: cargo test --verbose
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
       - name: Build CedarJava
         working-directory: ./CedarJava
         shell: bash
-        run: tail build.gradle && export MUST_RUN_CEDAR_INTEGRATION_TESTS=1 && ./gradlew build
+        run: export MUST_RUN_CEDAR_INTEGRATION_TESTS=1 && ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Build CedarJava
         working-directory: ./CedarJava
         shell: bash
-        run: ./gradlew build
+        run: tail gradlew && export MUST_RUN_CEDAR_INTEGRATION_TESTS=1 && ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       - name: cargo test
         working-directory: ./CedarJavaFFI
         run: cargo test --verbose
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Build CedarJava
         working-directory: ./CedarJava
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Build CedarJava
         working-directory: ./CedarJava
         shell: bash
-        run: tail gradlew && export MUST_RUN_CEDAR_INTEGRATION_TESTS=1 && ./gradlew build
+        run: tail build.gradle && export MUST_RUN_CEDAR_INTEGRATION_TESTS=1 && ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: cargo fmt
         working-directory: ./CedarJavaFFI
         run: cargo fmt --all --check
+      - name: configure
+        working-directory: ./CedarJava
+        shell: bash
+        run: bash config.sh run_int_tests
       - name: cargo rustc
         working-directory: ./CedarJavaFFI
         run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
@@ -37,4 +41,4 @@ jobs:
       - name: Build CedarJava
         working-directory: ./CedarJava
         shell: bash
-        run: bash config.sh run_int_tests && ./gradlew build
+        run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Build CedarJava
         working-directory: ./CedarJava
         shell: bash
-        run: bash config.sh && ./gradlew build
+        run: bash config.sh run_int_tests && ./gradlew build

--- a/CedarJava/README.md
+++ b/CedarJava/README.md
@@ -9,22 +9,32 @@ This package depends on [Cedar](https://www.cedarpolicy.com/), a library
 that needs to be compiled so that it can be run on the used platform.
 You need JDK 17 or later to run the code.
 
-You need to ensure the `CEDAR_JAVA_FFI_LIB` variable is set correctly. Typically running `config.sh` will set this for you.
+You need to ensure the `CEDAR_JAVA_FFI_LIB` variable is set correctly. Typically ./config.sh will set this for you.
 
 ### Building
 - Ensure Rust, Gradle and a JDK are installed.
-- clone `cedar-policy/cedar` into `cedar-java/cedar` (you don't have to build it)
 - then:
 ```shell
 cd CedarJavaFFI
 cargo build
 cargo test
 cd ../CedarJava
-bash config.sh
+./config.sh
 ./gradlew build
 ```
+This will run the tests as well (but not the integration tests).
 
-This will run the tests as well.
+If you want to run the integration tests, you'll also need:
+```shell
+export CEDAR_INTEGRATION_TESTS_ROOT=`path_to_cedar/cedar-integration-tests`
+```
+
+Otherwise you can do (done for you in `config.sh`):
+```shell
+export CEDAR_INTEGRATION_TESTS_ROOT=`/tmp`
+```
+And the tests won't be found (and hence won't be run).
+
 
 ## Debugging
 
@@ -37,7 +47,7 @@ Debugging calls across the JNI boundary is a bit tricky (as ever a bit more so o
 both a Java and native debugger (such as GDB/LLDB) to the program.
 
 ## Unsupported Features
-You can see a list of features not yet supported in CedarJava at [Differences from Rust](DIFFERENCES_FROM_RUST.md).  
+You can see a list of features not yet supported in CedarJava at [Differences from Rust](DIFFERENCES_FROM_RUST.md).
 
 ## Security
 

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -82,7 +82,7 @@ test {
     //environment "CEDAR_INTEGRATION_TESTS_ROOT", ''set to absolute path of `cedar-integration-tests`'
     //environment 'CEDAR_JAVA_FFI_LIB', 'set to absolute path of cedar_java_ffi native library (including file extension)'
     testLogging {
-        showStandardStreams false
+        showStandardStreams true
         exceptionFormat 'full'
     }
 }

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -82,7 +82,7 @@ test {
     //environment "CEDAR_INTEGRATION_TESTS_ROOT", ''set to absolute path of `cedar-integration-tests`'
     //environment 'CEDAR_JAVA_FFI_LIB', 'set to absolute path of cedar_java_ffi native library (including file extension)'
     testLogging {
-        showStandardStreams true
+        showStandardStreams false
         exceptionFormat 'full'
     }
 }

--- a/CedarJava/config.sh
+++ b/CedarJava/config.sh
@@ -35,3 +35,5 @@ else
     unset MUST_RUN_CEDAR_INTEGRATION_TESTS
     export CEDAR_INTEGRATION_TESTS_ROOT=/tmp
 fi
+
+tail gradlew

--- a/CedarJava/config.sh
+++ b/CedarJava/config.sh
@@ -1,23 +1,37 @@
 #!/bin/bash
 
+# If we run with anything but 1 or 2 args, exit with error code 1
+if [ "$#" -ne 0 ] && [ "$#" -ne 1 ]; then
+    echo "Wrong number of args:" $#
+    exit 1;
+fi
+
 parent_dir="$(dirname $(pwd))"
 
 #Try to set correctly for Mac and Linux machines
 if [ "$(uname)" == "Darwin" ]; then
-ffi_lib_str="    environment 'CEDAR_JAVA_FFI_LIB', '"$parent_dir"/CedarJavaFFI/target/debug/libcedar_java_ffi.dylib'"
+    ffi_lib_str="    environment 'CEDAR_JAVA_FFI_LIB', '"$parent_dir"/CedarJavaFFI/target/debug/libcedar_java_ffi.dylib'"
 else
-ffi_lib_str="    environment 'CEDAR_JAVA_FFI_LIB', '"$parent_dir"/CedarJavaFFI/target/debug/libcedar_java_ffi.so'"
+    ffi_lib_str="    environment 'CEDAR_JAVA_FFI_LIB', '"$parent_dir"/CedarJavaFFI/target/debug/libcedar_java_ffi.so'"
 fi
 sed "83s;.*;$ffi_lib_str;" "build.gradle" > new_build.gradle
 mv new_build.gradle build.gradle
 
-integration_tests_str="    environment 'CEDAR_INTEGRATION_TESTS_ROOT', '"$parent_dir"/cedar/cedar-integration-tests'"
-sed "82s;.*;$integration_tests_str;" "build.gradle" > new_build.gradle
-mv new_build.gradle build.gradle
+# In CI, we need to pull the latest cedar-policy to match the latest cedar-integration-tests
+# We require that integration tests be run
+# Outside of CI, we can skip the integration tests (run script with no args)
+# If you call this script with `run_int_tests`, we assume you have `cedar` checkout out in the `cedar-java` dir
+if [ "$#" -ne 0 ] && [ "$1" == "run_int_tests" ]; then
+    integration_tests_str="    environment 'CEDAR_INTEGRATION_TESTS_ROOT', '"$parent_dir"/cedar/cedar-integration-tests'"
+    sed "82s;.*;$integration_tests_str;" "build.gradle" > new_build.gradle
+    mv new_build.gradle build.gradle
 
-export MUST_RUN_CEDAR_INTEGRATION_TESTS=1
+    export MUST_RUN_CEDAR_INTEGRATION_TESTS=1
 
-tail build.gradle
-
-ls ..
-ls ../..
+    cargo_str='cedar-policy = { version = "2.3", path = "../cedar/cedar-policy" }'
+    sed "12s;.*;$cargo_str;" "../CedarJavaFFI/Cargo.toml" > new_Cargo.toml
+    mv new_Cargo.toml ../CedarJavaFFI/Cargo.toml
+else
+    unset MUST_RUN_CEDAR_INTEGRATION_TESTS
+    export CEDAR_INTEGRATION_TESTS_ROOT=/tmp
+fi

--- a/CedarJava/config.sh
+++ b/CedarJava/config.sh
@@ -36,4 +36,4 @@ else
     export CEDAR_INTEGRATION_TESTS_ROOT=/tmp
 fi
 
-tail gradlew
+tail build.gradle

--- a/CedarJava/config.sh
+++ b/CedarJava/config.sh
@@ -37,3 +37,5 @@ else
 fi
 
 tail build.gradle
+cat ../CedarJavaFFI/Cargo.toml
+ls /home/runner/work/cedar-java/cedar-java/cedar/cedar-integration-tests

--- a/CedarJava/config.sh
+++ b/CedarJava/config.sh
@@ -35,7 +35,3 @@ else
     unset MUST_RUN_CEDAR_INTEGRATION_TESTS
     export CEDAR_INTEGRATION_TESTS_ROOT=/tmp
 fi
-
-tail build.gradle
-cat ../CedarJavaFFI/Cargo.toml
-ls /home/runner/work/cedar-java/cedar-java/cedar/cedar-integration-tests

--- a/CedarJava/src/main/java/com/cedarpolicy/SliceJsonSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/SliceJsonSerializer.java
@@ -70,16 +70,22 @@ class SliceJsonSerializer extends JsonSerializer<Slice> {
             }
 
             this.attrs = e.attrs;
-            this.parents = new HashSet<JsonEUID>();
-            for (String parent : e.parents) {
-                String[] uid_parts = parent.split("::");
-                //Types cannot be empty but ids can. If the string ends with `:::` the id is `":"`. If the string ends with `::` the id is `""` and everything before the last `::` is the type.
-                String uid_id = parent.endsWith(":::") ? ":" : parent.endsWith("::") ? "" : uid_parts[uid_parts.length-1];
-                String uid_type = parent.substring(0, parent.length()-uid_id.length()-2);
+
+            if(e.getParents().isEmpty()) {
+                this.parents = new HashSet<JsonEUID>();
+
+                for (String parent : e.parents) {
+                    String[] uid_parts = parent.split("::");
+                    //Types cannot be empty but ids can. If the string ends with `:::` the id is `":"`. If the string ends with `::` the id is `""` and everything before the last `::` is the type.
+                    String uid_id = parent.endsWith(":::") ? ":" : parent.endsWith("::") ? "" : uid_parts[uid_parts.length - 1];
+                    String uid_type = parent.substring(0, parent.length() - uid_id.length() - 2);
 
 //                System.out.println("parent euid: "+(uid_type+"::\""+uid_id+"\""));
 
-                this.parents.add(new JsonEUID(uid_type, uid_id));
+                    this.parents.add(new JsonEUID(uid_type, uid_id));
+                }
+            } else {
+                this.parents = e.getParents().get();
             }
         }
     }

--- a/CedarJava/src/main/java/com/cedarpolicy/SliceJsonSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/SliceJsonSerializer.java
@@ -58,15 +58,28 @@ class SliceJsonSerializer extends JsonSerializer<Slice> {
         public final Set<JsonEUID> parents;
 
         JsonEntity(Entity e) {
-            String[] uid_parts = e.uid.split("::");
-            String uid_id = uid_parts[uid_parts.length-1];
-            String uid_type = e.uid.substring(0, e.uid.length()-uid_id.length()-2);
+            if(!e.getEuid().isEmpty()) {
+                this.uid = e.getEuid().get();
+            } else {
+                String[] uid_parts = e.uid.split("::");
+                //Types cannot be empty but ids can. If the string ends with `:::` the id is `":"`. If the string ends with `::` the id is `""` and everything before the last `::` is the type.
+                String uid_id = e.uid.endsWith(":::") ? ":" : e.uid.endsWith("::") ? "" : uid_parts[uid_parts.length-1];
+                String uid_type = e.uid.substring(0, e.uid.length()-uid_id.length()-2);
 
-            this.uid = new JsonEUID(uid_type, uid_id);
+                this.uid = new JsonEUID(uid_type, uid_id);
+            }
+
             this.attrs = e.attrs;
             this.parents = new HashSet<JsonEUID>();
             for (String parent : e.parents) {
-                this.parents.add(new JsonEUID(parent.split("::")[0], parent.split("::")[1]));
+                String[] uid_parts = parent.split("::");
+                //Types cannot be empty but ids can. If the string ends with `:::` the id is `":"`. If the string ends with `::` the id is `""` and everything before the last `::` is the type.
+                String uid_id = parent.endsWith(":::") ? ":" : parent.endsWith("::") ? "" : uid_parts[uid_parts.length-1];
+                String uid_type = parent.substring(0, parent.length()-uid_id.length()-2);
+
+//                System.out.println("parent euid: "+(uid_type+"::\""+uid_id+"\""));
+
+                this.parents.add(new JsonEUID(uid_type, uid_id));
             }
         }
     }

--- a/CedarJava/src/main/java/com/cedarpolicy/SliceJsonSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/SliceJsonSerializer.java
@@ -63,6 +63,7 @@ class SliceJsonSerializer extends JsonSerializer<Slice> {
             String uid_type = e.uid.substring(0, e.uid.length()-uid_id.length()-2);
 
             this.uid = new JsonEUID(uid_type, uid_id);
+
             this.attrs = e.attrs;
             this.parents = new HashSet<JsonEUID>();
             for (String parent : e.parents) {

--- a/CedarJava/src/main/java/com/cedarpolicy/SliceJsonSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/SliceJsonSerializer.java
@@ -63,7 +63,6 @@ class SliceJsonSerializer extends JsonSerializer<Slice> {
             String uid_type = e.uid.substring(0, e.uid.length()-uid_id.length()-2);
 
             this.uid = new JsonEUID(uid_type, uid_id);
-
             this.attrs = e.attrs;
             this.parents = new HashSet<JsonEUID>();
             for (String parent : e.parents) {

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/Entity.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/Entity.java
@@ -18,10 +18,8 @@ package com.cedarpolicy.model.slice;
 
 import com.cedarpolicy.serializer.JsonEUID;
 import com.cedarpolicy.value.Value;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -33,6 +31,8 @@ import java.util.stream.Collectors;
 public class Entity {
     /** EUID of this entity object. */
     public final String uid;
+
+    private final Optional<JsonEUID> euid;
 
     /** Key/Value attribute map. */
     public final Map<String, Value> attrs;
@@ -51,6 +51,7 @@ public class Entity {
         this.uid = uid;
         this.attrs = new HashMap<>(attributes);
         this.parents = parents;
+        this.euid = Optional.empty();
     }
 
     /**
@@ -62,6 +63,7 @@ public class Entity {
         this.uid = uid;
         this.attrs = new HashMap<>();
         this.parents = new HashSet<>();
+        this.euid = Optional.empty();
     }
 
     /**
@@ -75,6 +77,7 @@ public class Entity {
         this.uid = uid.toString();
         this.attrs = new HashMap<>(attributes);
         this.parents = parents;
+        this.euid = Optional.of(uid);
     }
 
     @Override
@@ -92,5 +95,13 @@ public class Entity {
                                     .collect(Collectors.joining("\n\t\t"));
         }
         return uid + parentStr + attributeStr;
+    }
+
+    /**
+     * Get entity uid in JsonEUID format
+     * @return Entity UID in JsonEUID format
+     */
+    public Optional<JsonEUID> getEuid() {
+        return euid;
     }
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/Entity.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/Entity.java
@@ -40,6 +40,9 @@ public class Entity {
     /** Set of entity EUIDs that are parents to this entity. */
     public final Set<String> parents;
 
+    /** Set of entity EUIDs that are parents to this entity. */
+    public final Optional<Set<JsonEUID>> parentsEUIDs;
+
     /**
      * Create an entity from unwrapped JSON values.
      *
@@ -52,6 +55,7 @@ public class Entity {
         this.attrs = new HashMap<>(attributes);
         this.parents = parents;
         this.euid = Optional.empty();
+        this.parentsEUIDs = Optional.empty();
     }
 
     /**
@@ -64,6 +68,7 @@ public class Entity {
         this.attrs = new HashMap<>();
         this.parents = new HashSet<>();
         this.euid = Optional.empty();
+        this.parentsEUIDs = Optional.empty();
     }
 
     /**
@@ -78,6 +83,22 @@ public class Entity {
         this.attrs = new HashMap<>(attributes);
         this.parents = parents;
         this.euid = Optional.of(uid);
+        this.parentsEUIDs = Optional.empty();
+    }
+
+    /**
+     * Create an entity from JsonEUID and unwrapped JSON values.
+     *
+     * @param uid Euid of the Entity.
+     * @param attributes Key/Value map of attributes.
+     * @param parents Set of parent entities.
+     */
+    public Entity(JsonEUID uid, Map<String, Value> attributes, Set<String> parents, Set<JsonEUID> parentsEUIDs) {
+        this.uid = uid.toString();
+        this.attrs = new HashMap<>(attributes);
+        this.parents = parents;
+        this.euid = Optional.of(uid);
+        this.parentsEUIDs = Optional.of(parentsEUIDs);
     }
 
     @Override
@@ -103,5 +124,13 @@ public class Entity {
      */
     public Optional<JsonEUID> getEuid() {
         return euid;
+    }
+
+    /**
+     * Get entity uid in JsonEUID format
+     * @return Entity UID in JsonEUID format
+     */
+    public Optional<Set<JsonEUID>> getParents() {
+        return parentsEUIDs;
     }
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityUID.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityUID.java
@@ -16,6 +16,7 @@
 
 package com.cedarpolicy.value;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -62,6 +63,13 @@ public class EntityUID extends Value {
     /** Entity uid. */
     private final String euid;
 
+    /** Entity uid type. */
+    private final Optional<String> type;
+
+    /** Entity uid type. */
+    private final Optional<String> id;
+
+
     /**
      * Build EntityUID.
      *
@@ -74,6 +82,8 @@ public class EntityUID extends Value {
         }
 
         this.euid = euid;
+        this.type = Optional.empty();
+        this.id = Optional.empty();
     }
 
     /**
@@ -89,6 +99,8 @@ public class EntityUID extends Value {
             throw new IllegalArgumentException("Input string is not a valid EntityUID " + euid);
         }
         this.euid = euid;
+        this.type = Optional.of(type);
+        this.id = Optional.of(id);
     }
 
     /** As String. */
@@ -105,11 +117,17 @@ public class EntityUID extends Value {
 
     /** Get the type of the EUID. */
     public String getType() {
+        if(!this.type.isEmpty()) {
+            return this.type.get();
+        }
         return this.euid.substring(0, this.euid.length()-this.getId().length()-4);
     }
 
     /** Get the ID of the EUID. */
     public String getId() {
+        if(!this.id.isEmpty()) {
+            return this.id.get();
+        }
         String[] strs = this.euid.split("::");
         return strs[strs.length-1].substring(1,strs[strs.length-1].length()-1);
     }

--- a/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
@@ -149,6 +149,16 @@ public class JSONTests {
         inner.put("type", "User");
         n.put(ENTITY_ESCAPE_SEQ, inner);
         assertJSONEqual(n, uid);
+
+        String weirdType = "a";
+        String weirdId = "";
+        String weirdEID = weirdType+"::\""+weirdId+"\"";
+        uid = new EntityUID(weirdEID);
+        inner = JsonNodeFactory.instance.objectNode();
+        inner.put("id", weirdId);
+        inner.put("type", weirdType);
+        n.put(ENTITY_ESCAPE_SEQ, inner);
+        assertJSONEqual(n, uid);
     }
 
     /** Test. */

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -224,7 +224,7 @@ public class SharedIntegrationTests {
                    .filter(path -> path.getFileName().toString().endsWith(".json"))
                    //TODO: fix this
                    //Parsing of one policy in our corpus tests is broken due to a `;` in a string. Disable for now:
-                //    .filter(p -> !p.getFileName().toString().endsWith("54d561c25c3da949ee5e512f2ccd85af57ba9502.json"))
+                   .filter(p -> !p.getFileName().toString().endsWith("54d561c25c3da949ee5e512f2ccd85af57ba9502.json"))
                    // ignore files that start with policies_, entities_, or schema_
                    .filter(
                            path ->

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -176,28 +176,28 @@ public class SharedIntegrationTests {
      * files in this array will be executed as integration tests.
      */
     private static final String[] JSON_TEST_FILES = {
-        "tests/example_use_cases_doc/1a.json",
-        "tests/example_use_cases_doc/2a.json",
-        "tests/example_use_cases_doc/2b.json",
-        "tests/example_use_cases_doc/2c.json",
-        "tests/example_use_cases_doc/3a.json",
-        "tests/example_use_cases_doc/3b.json",
-        "tests/example_use_cases_doc/3c.json",
-        // "tests/example_use_cases_doc/4a.json", // currently disabled due to action attributes
-        // "tests/example_use_cases_doc/4c.json", // currently disabled due to action attributes
-        // "tests/example_use_cases_doc/4d.json", // currently disabled due to action attributes
-        // "tests/example_use_cases_doc/4e.json", // currently disabled due to action attributes
-        // "tests/example_use_cases_doc/4f.json", // currently disabled due to action attributes
-        // "tests/example_use_cases_doc/5b.json", // currently disabled due to action attributes
-        // Need to change extension handling to match natural JSON CRs
-        "tests/ip/1.json",
-        "tests/ip/2.json",
-        "tests/ip/3.json",
-        "tests/multi/1.json",
-        "tests/multi/2.json",
-        // "tests/multi/3.json", // currently disabled because it uses action attributes
-        // "tests/multi/4.json", // currently disabled because it uses action attributes
-        // "tests/multi/5.json", // currently disabled because it uses action attributes
+//        "tests/example_use_cases_doc/1a.json",
+//        "tests/example_use_cases_doc/2a.json",
+//        "tests/example_use_cases_doc/2b.json",
+//        "tests/example_use_cases_doc/2c.json",
+//        "tests/example_use_cases_doc/3a.json",
+//        "tests/example_use_cases_doc/3b.json",
+//        "tests/example_use_cases_doc/3c.json",
+//        // "tests/example_use_cases_doc/4a.json", // currently disabled due to action attributes
+//        // "tests/example_use_cases_doc/4c.json", // currently disabled due to action attributes
+//        // "tests/example_use_cases_doc/4d.json", // currently disabled due to action attributes
+//        // "tests/example_use_cases_doc/4e.json", // currently disabled due to action attributes
+//        // "tests/example_use_cases_doc/4f.json", // currently disabled due to action attributes
+//        // "tests/example_use_cases_doc/5b.json", // currently disabled due to action attributes
+//        // Need to change extension handling to match natural JSON CRs
+//        "tests/ip/1.json",
+//        "tests/ip/2.json",
+//        "tests/ip/3.json",
+//        "tests/multi/1.json",
+//        "tests/multi/2.json",
+//        // "tests/multi/3.json", // currently disabled because it uses action attributes
+//        // "tests/multi/4.json", // currently disabled because it uses action attributes
+//        // "tests/multi/5.json", // currently disabled because it uses action attributes
     };
 
     /**
@@ -217,29 +217,29 @@ public class SharedIntegrationTests {
             tests.add(loadJsonTests(testFile));
         }
         // corpus tests
-//        try (Stream<Path> stream =
-//                Files.list(Paths.get(CEDAR_INTEGRATION_TESTS_ROOT, "corpus_tests"))) {
-//            stream
-//                    // ignore non-JSON files
-//                    .filter(path -> path.getFileName().toString().endsWith(".json"))
-//                    // ignore files that start with policies_, entities_, or schema_
-//                    .filter(
-//                            path ->
-//                                    !path.getFileName().toString().startsWith("policies_")
-//                                            && !path.getFileName().toString().startsWith("entities_")
-//                                            && !path.getFileName().toString().startsWith("schema_"))
-//                    // add the test
-//                    .forEach(
-//                            path -> {
-//                                try {
-//                                    tests.add(loadJsonTests(path.toAbsolutePath().toString()));
-//                                } catch (final IOException e) {
-//                                    // inside the forEach we can't throw checked exceptions, but we
-//                                    // can throw this unchecked exception
-//                                    throw new UncheckedIOException(e);
-//                                }
-//                            });
-//        }
+       try (Stream<Path> stream =
+               Files.list(Paths.get(CEDAR_INTEGRATION_TESTS_ROOT, "corpus_tests"))) {
+           stream
+                   // ignore non-JSON files
+                   .filter(path -> path.getFileName().toString().endsWith("9cc9.json"))
+                   // ignore files that start with policies_, entities_, or schema_
+                   .filter(
+                           path ->
+                                   !path.getFileName().toString().startsWith("policies_")
+                                           && !path.getFileName().toString().startsWith("entities_")
+                                           && !path.getFileName().toString().startsWith("schema_"))
+                   // add the test
+                   .forEach(
+                           path -> {
+                               try {
+                                   tests.add(loadJsonTests(path.toAbsolutePath().toString()));
+                               } catch (final IOException e) {
+                                   // inside the forEach we can't throw checked exceptions, but we
+                                   // can throw this unchecked exception
+                                   throw new UncheckedIOException(e);
+                               }
+                           });
+       }
         return tests;
     }
 
@@ -315,7 +315,7 @@ public class SharedIntegrationTests {
         HashSet<String> parents = new HashSet<String>();
 
         je.parents.forEach(p -> parents.add(p.toString()));
-        return new Entity(je.uid.toString(), je.attrs, parents);
+        return new Entity(je.uid, je.attrs, parents);
     }
 
     /**
@@ -326,7 +326,6 @@ public class SharedIntegrationTests {
      * objects instead of strings.
      */
     private Set<Entity> loadEntities(String entitiesFile) throws IOException {
-        System.out.println("Entities file: "+entitiesFile);
         try (InputStream entitiesIn =
                 new FileInputStream(resolveIntegrationTestPath(entitiesFile).toFile())) {
             return Arrays.stream(OBJECT_MAPPER.reader().readValue(entitiesIn, JsonEntity[].class))
@@ -345,9 +344,9 @@ public class SharedIntegrationTests {
         AuthorizationEngine auth = new BasicAuthorizationEngine();
         AuthorizationRequest authQuery =
                 new AuthorizationRequest(
-                        Optional.of(query.principal),
+                        query.principal == null ? Optional.empty() : Optional.of(query.principal),
                         query.action,
-                         Optional.of(query.resource),
+                        query.resource == null ? Optional.empty() : Optional.of(query.resource),
                          Optional.of(query.context),
                         Optional.of(schema));
         Slice slice = new BasicSlice(policies, entities);

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -224,7 +224,7 @@ public class SharedIntegrationTests {
                    .filter(path -> path.getFileName().toString().endsWith(".json"))
                    //TODO: fix this
                    //Parsing of one policy in our corpus tests is broken due to a `;` in a string. Disable for now:
-                   .filter(p -> !p.getFileName().toString().endsWith("54d561c25c3da949ee5e512f2ccd85af57ba9502.json"))
+                //    .filter(p -> !p.getFileName().toString().endsWith("54d561c25c3da949ee5e512f2ccd85af57ba9502.json"))
                    // ignore files that start with policies_, entities_, or schema_
                    .filter(
                            path ->


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/cedar-policy/cedar-java/issues/30

*Description of changes:*

Enable corpus tests. Fix failures.

Disabled two classes of tests:
Tests with policy parsing errors that don't match Rust errors
`12864 tests completed, 48 failed`

Tests with `;` in policy string
`12872 tests completed, 8 failed`
(these DENY when Rust gives ALLOW; java splits policies based on `;` so a policy fails to parse)

This is pretty messy, but probably worth merging now and cleaning up later to enable corpus tests.


We also need to ensure CI runs with CedarJavaFFI pulling in cedar-policy from `main` instead of crates.io because the corpus tests are pulled from `main` and the error messages may not match exactly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
