### PR TITLE
Updates to documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,9 +13,9 @@ body:
       label: |
         Before opening, please confirm:
       options:
-        - label: I have [searched for duplicate or closed issues](https://github.com/cedar-policy/cedar/issues?q=is%3Aissue+).
+        - label: I have [searched for duplicate or closed issues](https://github.com/cedar-policy/cedar-java/issues?q=is%3Aissue+).
           required: true
-        - label: I have read the guide for [submitting bug reports](https://github.com/cedar-policy/cedar/blob/main/CONTRIBUTING.md#bug-reports).
+        - label: I have read the guide for [submitting bug reports](https://github.com/cedar-policy/cedar-java/blob/main/CONTRIBUTING.md#bug-reports).
           required: true
         - label: I have done my best to include a minimal, self-contained set of instructions for consistently reproducing the issue.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -16,8 +16,10 @@ body:
       options:
         - Cedar language features
         - Cedar validation features
-        - Cedar grammar changes/additions
+        - Cedar syntax changes/additions
         - User level API changes
+        - Internal refactors/changes
+        - Documentation and code comments
         - Other
     validations:
       required: true
@@ -27,14 +29,6 @@ body:
       label: Describe the feature you'd like to request
       description: |
         A clear and concise description of what you want to happen. Please include **any related issues**, documentation, etc.
-    validations:
-      required: true
-
-  - type: textarea
-    attributes:
-      label: Describe the solution you'd like
-      description: |
-        A clear and concise description of your proposed solution.
     validations:
       required: true
 
@@ -58,4 +52,3 @@ body:
       options:
         - label: 👋 I may be able to implement this feature request
         - label: ⚠️ This feature might incur a breaking change
-

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an idea for Cedar
+description: Suggest an idea for CedarJava
 labels: [pending-triage, feature-request]
 
 body:
@@ -11,12 +11,9 @@ body:
   - type: dropdown
     attributes:
       label: Category
-      description: What component of Cedar does this feature relate to?
+      description: What component of CedarJava does this feature relate to?
       multiple: true
       options:
-        - Cedar language features
-        - Cedar validation features
-        - Cedar syntax changes/additions
         - User level API changes
         - Internal refactors/changes
         - Documentation and code comments

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -79,8 +79,8 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    environment 'CEDAR_INTEGRATION_TESTS_ROOT', '/Users/khieta/Code/cedar-policy/cedar/cedar-integration-tests'
-    environment 'CEDAR_JAVA_FFI_LIB', '/Users/khieta/Code/cedar-policy/cedar-java/CedarJavaFFI/target/debug/libcedar_java_ffi.dylib'
+    //environment "CEDAR_INTEGRATION_TESTS_ROOT", ''set to absolute path of `cedar-integration-tests`'
+    //environment 'CEDAR_JAVA_FFI_LIB', 'set to absolute path of cedar_java_ffi native library (including file extension)'
     testLogging {
         showStandardStreams false
         exceptionFormat 'full'

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -79,8 +79,8 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    //environment "CEDAR_INTEGRATION_TESTS_ROOT", ''set to absolute path of `cedar-integration-tests`'
-    //environment 'CEDAR_JAVA_FFI_LIB', 'set to absolute path of cedar_java_ffi native library (including file extension)'
+    environment 'CEDAR_INTEGRATION_TESTS_ROOT', '/Users/khieta/Code/cedar-policy/cedar/cedar-integration-tests'
+    environment 'CEDAR_JAVA_FFI_LIB', '/Users/khieta/Code/cedar-policy/cedar-java/CedarJavaFFI/target/debug/libcedar_java_ffi.dylib'
     testLogging {
         showStandardStreams false
         exceptionFormat 'full'

--- a/CedarJavaFFI/Cargo.toml
+++ b/CedarJavaFFI/Cargo.toml
@@ -9,7 +9,7 @@ version = "2.0.0"
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-cedar-policy = { version = "2.3" }
+cedar-policy = { version = "2.3", path = "../cedar/cedar-policy" }
 
 # JNI Support
 jni = "0.20.0"

--- a/CedarJavaFFI/README.md
+++ b/CedarJavaFFI/README.md
@@ -12,7 +12,7 @@ You can build the code with
 cargo build
 ```
 
-Note that the `main` branch expects that the [cedar](https://github.com/cedar-policy/cedar) repository is cloned locally in the top-level directory (`..`). `release/x.x.x` branches uses a version of`cedar-policy` available on [crates.io](https://crates.io/crates/cedar-policy).
+Note that the `main` branch expects that the [cedar](https://github.com/cedar-policy/cedar) repository is cloned locally in the top-level directory (`..`). `release/x.x.x` branches use a version of `cedar-policy` available on [crates.io](https://crates.io/crates/cedar-policy).
 
 ### Run
 

--- a/CedarJavaFFI/README.md
+++ b/CedarJavaFFI/README.md
@@ -1,26 +1,32 @@
-## CedarJavaFFI
+# CedarJavaFFI
+
 Bindings to allow calling the core Cedar functions (`is_authorized` and `validate`) from Java.
 
 ## Usage
 
 ### Build
+
 You can build the code with
+
 ```shell
 cargo build
 ```
 
+Note that the `main` branch expects that the [cedar](https://github.com/cedar-policy/cedar) repository is cloned locally in the top-level directory (`..`). `release/x.x.x` branches uses a version of`cedar-policy` available on [crates.io](https://crates.io/crates/cedar-policy).
+
 ### Run
+
 You can test the code with
+
 ```shell
 cargo test
 ```
-
 
 Typically you will want to use `../CedarJava` in your project and won't care about `CedarJavaFFI`.
 
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](../CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-## Cedar Java
+# cedar-java
 
-This repository contains `CedarJavaFFI`, a Rust crate to allow calling the Cedar library from Java and `CedarJava`, a Java package to make calling Cedar from Java more convenient.
+This repository contains the source code for a Java package `CedarJava` that supports using the [Cedar](https://www.cedarpolicy.com) policy language.
+It also contains source code for a Rust crate `CedarJavaFFI` that enables calling Cedar library functions (written in Rust) from Java.
 
 You can find build instructions and more information in the subfolders.
 
-## Note
+## Notes
+
 You need JDK 17 or later to run the Java code.
 
-Cedar is primarily developed in Rust. CedarJava typically lags behind the newest Cedar features. Notably, as of this writing, Cedar Java does not expose Partial Evaluation APIs.
+Cedar is primarily developed in Rust (in the [cedar](https://github.com/cedar-policy/cedar) repository). As such, `CedarJava` typically lags behind the newest Cedar features. Notably, as of this writing, `CedarJava` does not expose APIs for partial evaluation.
+
+The `main` branch of this repository is kept up-to-date with the development version of the Rust code (available in the `main` branch of [cedar](https://github.com/cedar-policy/cedar)). Unless you plan to build the Rust code locally, please use the latest `release/x.x.x` branch instead.
 
 ## Security
 
@@ -16,4 +20,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This project is licensed under the Apache-2.0 License.
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Revised text in the toplevel README to indicate that users should use a `release` branch unless they're building the `cedar-policy` crate locally.
* Updated the `Cargo.toml` in `CedarJavaFFI` to point to a local copy of `cedar` rather than the one available on crates.io.
* Updated links in `bug_report.yml` to point to the correct repo.
* Copied `feature_request.yml` from our [`cedar`](https://github.com/cedar-policy/cedar) repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
