### PR TITLE
add parse euid api

### DIFF
--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -129,7 +129,7 @@ struct ParseEUIDOutput {
     id: String,
 }
 
-/// public string-based JSON interfaced to be invoked by FFIs. Takes in a `ParseEUIDCall`, parses it and (if successful)
+/// public string-based JSON interface to be invoked by FFIs. Takes in a `ParseEUIDCall`, parses it and (if successful)
 /// returns a serialized `ParseEUIDOutput`
 pub fn json_parse_entity_uid(input: &str) -> InterfaceResult {
     match serde_json::from_str::<ParseEUIDCall>(input) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add parse euid api

Needed to deprecate `__expr` escape in `3.0` (https://github.com/cedar-policy/cedar/pull/333)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
