### PR TITLE
Reduce implementation dependencies

### DIFF
--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -60,18 +60,19 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    testCompileOnly.extendsFrom compileOnly
+}
+
 dependencies {
     // Do not upgrade to Jackson 3.x without addressing stack overflow issues in ValueCedarDeserializer
     // The upgrade should be reviewed by AppSec
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.15.0'
     implementation 'org.slf4j:slf4j-api:2.0.7'
-    implementation 'org.apache.commons:commons-text:1.10.0'
-    implementation 'com.google.code.findbugs:findbugs:3.0.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.20.0'
-    implementation 'com.google.guava:guava:31.0.1-jre'
-
+    compileOnly 'com.google.code.findbugs:findbugs:3.0.1'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.20.0'
+    testImplementation 'org.apache.logging.log4j:log4j-to-slf4j:2.20.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
     testImplementation 'org.mockito:mockito-inline:5.2.0'

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
@@ -19,10 +19,9 @@ package com.cedarpolicy.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * The result of processing an AuthorizationRequest. The answer to the request is contained in the
@@ -54,10 +53,10 @@ public final class AuthorizationResponse {
          * Set of policyID's that caused the decision. For example, when a policy evaluates to Deny,
          * all deny policies that evaluated to True will appear in Reasons.
          */
-        private ImmutableSet<String> reason;
+        private Set<String> reason;
 
         /** Set of errors and warnings returned by Cedar. */
-        private ImmutableList<String> errors;
+        private List<String> errors;
 
         /**
          * Read the reasons and errors from a JSON object.
@@ -69,8 +68,8 @@ public final class AuthorizationResponse {
         public Diagnostics(
                 @JsonProperty("reason") Set<String> reason,
                 @JsonProperty("errors") List<String> errors) {
-            this.errors = ImmutableList.copyOf(errors);
-            this.reason = ImmutableSet.copyOf(reason);
+            this.errors = Collections.unmodifiableList(errors);
+            this.reason = Collections.unmodifiableSet(reason);
         }
     }
 
@@ -137,7 +136,7 @@ public final class AuthorizationResponse {
      *
      * @return list with errors that happened for a given Request
      */
-    public java.util.List<String> getErrors() {
+    public List<String> getErrors() {
         return diagnostics.errors;
     }
 

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/TemplateInstantiation.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/TemplateInstantiation.java
@@ -18,8 +18,8 @@ package com.cedarpolicy.model.slice;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
 import java.util.List;
-import com.google.common.collect.ImmutableList;
 
 /** Template instantiation. */
 public class TemplateInstantiation {
@@ -46,7 +46,7 @@ public class TemplateInstantiation {
             @JsonProperty("instantiations") List<Instantiation> instantiations) {
         this.templateId = templateId;
         this.resultPolicyId = resultPolicyId;
-        this.instantiations = ImmutableList.copyOf(instantiations);
+        this.instantiations = Collections.unmodifiableList(instantiations);
     }
 
     /** Get the template ID. */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pull request reduces the number and scope of dependencies required for the `cedar-java` library.

Changes include the following:

- Removed unused Apache Commons Text
- Removed Google Guava
- Replaced Guava ImmutableList with Collection.unmodifiableList()
- Changed FindBugs annotations library to compileOnly
- Changed Log4j 2 to testImplementation

Apache Commons Text did not have any direct references in Java classes. Log4j 2 is only necessary for test classes, so it should be declared as a test implementation dependency, allowing runtime integrations to provide an SLF4J implementation as needed.

FindBugs provides annotations to suppress FindBugs warnings, but these annotations are not necessary for runtime operation, as Java Virtual Machines ignore missing annotation classes when loading.

Usage of Google Guava was limited to `ImmutableList` and `ImmutableSet` in two classes. These references can be replaced with standard Java wrappers `Collections.unmodifiableList()` and `Collections.unmodifiableSet()`, avoiding the need for Guava entirely.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
