### PR TITLE
Fix build by reinstating Guava dependency

### DIFF
--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple:2.0.12'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testImplementation 'net.jqwik:jqwik:1.8.2'
+    implementation 'com.google.guava:guava:33.0.0-jre'
 }
 
 test {

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -70,11 +70,11 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.1'
     implementation 'org.slf4j:slf4j-api:2.0.12'
+    implementation 'com.google.guava:guava:33.0.0-jre'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.3'
     testImplementation 'org.slf4j:slf4j-simple:2.0.12'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testImplementation 'net.jqwik:jqwik:1.8.2'
-    implementation 'com.google.guava:guava:33.0.0-jre'
 }
 
 test {

--- a/CedarJava/config.sh
+++ b/CedarJava/config.sh
@@ -14,7 +14,7 @@ if [ "$(uname)" == "Darwin" ]; then
 else
     ffi_lib_str="    environment 'CEDAR_JAVA_FFI_LIB', '"$parent_dir"/CedarJavaFFI/target/debug/libcedar_java_ffi.so'"
 fi
-sed "85s;.*;$ffi_lib_str;" "build.gradle" > new_build.gradle
+sed "83s;.*;$ffi_lib_str;" "build.gradle" > new_build.gradle
 mv new_build.gradle build.gradle
 
 # In CI, we need to pull the latest cedar-policy to match the latest cedar-integration-tests
@@ -23,7 +23,7 @@ mv new_build.gradle build.gradle
 # If you call this script with `run_int_tests`, we assume you have `cedar` checkout out in the `cedar-java` dir
 if [ "$#" -ne 0 ] && [ "$1" == "run_int_tests" ]; then
     integration_tests_str="    environment 'CEDAR_INTEGRATION_TESTS_ROOT', '"$parent_dir"/cedar/cedar-integration-tests'"
-    sed "84s;.*;$integration_tests_str;" "build.gradle" > new_build.gradle
+    sed "82s;.*;$integration_tests_str;" "build.gradle" > new_build.gradle
     mv new_build.gradle build.gradle
 
     export MUST_RUN_CEDAR_INTEGRATION_TESTS=1

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
@@ -19,9 +19,10 @@ package com.cedarpolicy.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * The result of processing an AuthorizationRequest. The answer to the request is contained in the
@@ -53,10 +54,10 @@ public final class AuthorizationResponse {
          * Set of policyID's that caused the decision. For example, when a policy evaluates to Deny,
          * all deny policies that evaluated to True will appear in Reasons.
          */
-        private Set<String> reason;
+        private ImmutableSet<String> reason;
 
         /** Set of errors and warnings returned by Cedar. */
-        private List<String> errors;
+        private ImmutableList<String> errors;
 
         /**
          * Read the reasons and errors from a JSON object.
@@ -68,8 +69,8 @@ public final class AuthorizationResponse {
         public Diagnostics(
                 @JsonProperty("reason") Set<String> reason,
                 @JsonProperty("errors") List<String> errors) {
-            this.errors = Collections.unmodifiableList(errors);
-            this.reason = Collections.unmodifiableSet(reason);
+            this.errors = ImmutableList.copyOf(errors);
+            this.reason = ImmutableSet.copyOf(reason);
         }
 
         /**
@@ -155,7 +156,7 @@ public final class AuthorizationResponse {
      *
      * @return list with errors that happened for a given Request
      */
-    public List<String> getErrors() {
+    public java.util.List<String> getErrors() {
         return diagnostics.errors;
     }
 

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
@@ -156,7 +156,7 @@ public final class AuthorizationResponse {
      *
      * @return list with errors that happened for a given Request
      */
-    public java.util.List<String> getErrors() {
+    public List<String> getErrors() {
         return diagnostics.errors;
     }
 

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/TemplateInstantiation.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/TemplateInstantiation.java
@@ -18,8 +18,8 @@ package com.cedarpolicy.model.slice;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Collections;
 import java.util.List;
+import com.google.common.collect.ImmutableList;
 
 /** Template instantiation. */
 public class TemplateInstantiation {
@@ -46,7 +46,7 @@ public class TemplateInstantiation {
             @JsonProperty("instantiations") List<Instantiation> instantiations) {
         this.templateId = templateId;
         this.resultPolicyId = resultPolicyId;
-        this.instantiations = Collections.unmodifiableList(instantiations);
+        this.instantiations = ImmutableList.copyOf(instantiations);
     }
 
     /** Get the template ID. */


### PR DESCRIPTION
This fixes an error caused by conflicting merges. A PR added new code which depended on Guava while another deleted the dependency. 

The commit adds the dependency rather than updating the code to not require the dependency because my understanding is that Guava immutable sets provide better guarantees than Java unmodifiable collections. Specifically, unmodifiable sets hold a reference to the set used in their construction. If a reference is kept to the set used to construct an unmodifiable set, then any mutation to that set is reflected in the unmodifiable set. The Guava immutable set creates a copy.

In any case where we store the set in a field of an object, we should use guava immutable types. When _returning_ a collection, we can use the builtin unmodifiable methods to avoid copying the data.