### PR TITLE
Make `sed` edits in `config.sh` more robust

### DIFF
--- a/CedarJava/config.sh
+++ b/CedarJava/config.sh
@@ -6,6 +6,24 @@ if [ "$#" -ne 0 ] && [ "$#" -ne 1 ]; then
     exit 1;
 fi
 
+# Find and replace a pattern with some text in a file using `sed`, but first
+# check that the pattern occurs in the file exactly once.
+replace_once() {
+    local replace_in_file="$1"
+    local pattern="$2"
+    local replace_with="$3"
+
+    local match_count
+    match_count="$(grep -c "$pattern" "$replace_in_file")"
+    if [ "$match_count" -ne 1 ]; then
+        echo "Expected $pattern would match exactly once in $replace_in_file, but it matched $match_count times"
+        exit 1
+    fi
+
+    sed -i.bak "s;$pattern;$replace_with;" "$replace_in_file"
+    rm "$replace_in_file".bak
+}
+
 parent_dir="$(dirname $(pwd))"
 
 #Try to set correctly for Mac and Linux machines
@@ -14,8 +32,7 @@ if [ "$(uname)" == "Darwin" ]; then
 else
     ffi_lib_str="    environment 'CEDAR_JAVA_FFI_LIB', '"$parent_dir"/CedarJavaFFI/target/debug/libcedar_java_ffi.so'"
 fi
-sed "83s;.*;$ffi_lib_str;" "build.gradle" > new_build.gradle
-mv new_build.gradle build.gradle
+replace_once build.gradle ".*CEDAR_JAVA_FFI_LIB.*" "$ffi_lib_str"
 
 # In CI, we need to pull the latest cedar-policy to match the latest cedar-integration-tests
 # We require that integration tests be run
@@ -23,14 +40,12 @@ mv new_build.gradle build.gradle
 # If you call this script with `run_int_tests`, we assume you have `cedar` checkout out in the `cedar-java` dir
 if [ "$#" -ne 0 ] && [ "$1" == "run_int_tests" ]; then
     integration_tests_str="    environment 'CEDAR_INTEGRATION_TESTS_ROOT', '"$parent_dir"/cedar/cedar-integration-tests'"
-    sed "82s;.*;$integration_tests_str;" "build.gradle" > new_build.gradle
-    mv new_build.gradle build.gradle
+    replace_once build.gradle ".*CEDAR_INTEGRATION_TESTS_ROOT.*" "$integration_tests_str"
 
     export MUST_RUN_CEDAR_INTEGRATION_TESTS=1
 
     cargo_str='cedar-policy = { version = "3.0", path = "../cedar/cedar-policy" }'
-    sed "12s;.*;$cargo_str;" "../CedarJavaFFI/Cargo.toml" > new_Cargo.toml
-    mv new_Cargo.toml ../CedarJavaFFI/Cargo.toml
+    replace_once ../CedarJavaFFI/Cargo.toml ".*cedar-policy =.*" "$cargo_str"
 else
     unset MUST_RUN_CEDAR_INTEGRATION_TESTS
     export CEDAR_INTEGRATION_TESTS_ROOT=/tmp


### PR DESCRIPTION
Instead of using `sed` to replace a specific line number, the script now looks for a pattern describing the line to replace, verifies that the pattern appears exactly once in the file, and then replaces the line with the new contents. If the pattern doesn't appear or appears more than once, the CI will fail immediately. This is an improvement over the previous behavior where a change to the contents of one of the files would cause an incorrect line to be replaced, manifesting as an error somewhere later in the CI processes. 