### PR TITLE
Re-remove dependency on Guava

### DIFF
--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -70,7 +70,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.1'
     implementation 'org.slf4j:slf4j-api:2.0.12'
-    implementation 'com.google.guava:guava:33.0.0-jre'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.3'
     testImplementation 'org.slf4j:slf4j-simple:2.0.12'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Set;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * The result of processing an AuthorizationRequest. The answer to the request is contained in the
@@ -54,10 +52,10 @@ public final class AuthorizationResponse {
          * Set of policyID's that caused the decision. For example, when a policy evaluates to Deny,
          * all deny policies that evaluated to True will appear in Reasons.
          */
-        private ImmutableSet<String> reason;
+        private Set<String> reason;
 
         /** Set of errors and warnings returned by Cedar. */
-        private ImmutableList<String> errors;
+        private List<String> errors;
 
         /**
          * Read the reasons and errors from a JSON object.
@@ -69,8 +67,8 @@ public final class AuthorizationResponse {
         public Diagnostics(
                 @JsonProperty("reason") Set<String> reason,
                 @JsonProperty("errors") List<String> errors) {
-            this.errors = ImmutableList.copyOf(errors);
-            this.reason = ImmutableSet.copyOf(reason);
+            this.errors = List.copyOf(errors);
+            this.reason = Set.copyOf(reason);
         }
 
         /**

--- a/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationRequest.java
@@ -7,7 +7,6 @@ import com.cedarpolicy.model.slice.Entity;
 import com.cedarpolicy.value.EntityUID;
 import com.cedarpolicy.value.Value;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 import java.util.Optional;
@@ -158,7 +157,7 @@ public class PartialAuthorizationRequest extends AuthorizationRequest {
          * @return The builder.
          */
         public Builder context(Map<String, Value> context) {
-            this.context = ImmutableMap.copyOf(context);
+            this.context = Map.copyOf(context);
             return this;
         }
 

--- a/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationResponse.java
@@ -8,8 +8,9 @@ import com.cedarpolicy.model.slice.Policy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.stream.Collectors;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,17 +110,17 @@ public abstract class PartialAuthorizationResponse {
     }
 
     public static final class ResidualPartialAuthorizationResponse extends PartialAuthorizationResponse {
-        private final ImmutableSet<Policy> residuals;
+        private final Set<Policy> residuals;
 
         public ResidualPartialAuthorizationResponse(Map<String, JsonNode> residuals, Diagnostics diagnostics) {
             super(diagnostics);
             this.residuals = residuals.entrySet().stream()
                     .map(e -> new Policy(e.getValue().toString(), e.getKey()))
-                    .collect(ImmutableSet.toImmutableSet());
+                    .collect(Collectors.toUnmodifiableSet());
         }
 
         public Set<Policy> getResiduals() {
-            return this.residuals;
+            return Collections.unmodifiableSet(this.residuals);
         }
 
         @Override

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/TemplateInstantiation.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/TemplateInstantiation.java
@@ -19,7 +19,6 @@ package com.cedarpolicy.model.slice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import com.google.common.collect.ImmutableList;
 
 /** Template instantiation. */
 public class TemplateInstantiation {
@@ -46,7 +45,7 @@ public class TemplateInstantiation {
             @JsonProperty("instantiations") List<Instantiation> instantiations) {
         this.templateId = templateId;
         this.resultPolicyId = resultPolicyId;
-        this.instantiations = ImmutableList.copyOf(instantiations);
+        this.instantiations = List.copyOf(instantiations);
     }
 
     /** Get the template ID. */

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityTypeName.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityTypeName.java
@@ -1,8 +1,6 @@
 
 package com.cedarpolicy.value;
 
-import com.google.common.base.Suppliers;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.Objects;
@@ -34,7 +32,15 @@ public final class EntityTypeName {
     protected EntityTypeName(List<String> namespace, String  basename) {
         this.namespace = namespace;
         this.basename= basename;
-        this.entityTypeNameRepr = Suppliers.memoize(() -> getEntityTypeNameRepr(this));
+        this.entityTypeNameRepr = new Supplier<String>() {
+            String entityTypeNameRepr = null;
+            public String get() {
+                if (entityTypeNameRepr == null) {
+                    entityTypeNameRepr = getEntityTypeNameRepr(EntityTypeName.this);
+                }
+                return entityTypeNameRepr;
+            }
+        };
     }
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityUID.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityUID.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.cedarpolicy.serializer.JsonEUID;
-import com.google.common.base.Suppliers;
 
 /**
  * Represents a Cedar Entity UID. An entity UID contains both the entity type and a unique
@@ -44,7 +43,15 @@ public final class EntityUID extends Value {
     public EntityUID(EntityTypeName type, EntityIdentifier id) {
         this.type = type;
         this.id = id;
-        this.euidRepr = Suppliers.memoize(() -> getEUIDRepr(type, id));
+        this.euidRepr = new Supplier<String>() {
+            String uidRepr = null;
+            public String get() {
+                if (uidRepr == null) {
+                    uidRepr = getEUIDRepr(type, id);
+                }
+                return uidRepr;
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
Requires the following changes:

* Use `copyOf` and `unmodifiableSet` functions to replace `ImmutableSet`. Prefer using `copyOf` because it creates an unmodifiable copy of the set or list, so mutation to the input does not reflect in the new object. `unmodifiableSet` can still be used to return an immutable view of a set without causing any copying.

* Roll our own memoizing supplier. This change should be reviewed by someone with more Java knowledge, but, AFAIK, the behavior should be the same.

*Issue #, if available:*

#86 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
