### PR TITLE
Fix log statement (v2.4.x)

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
@@ -74,7 +74,7 @@ public final class BasicAuthorizationEngine implements AuthorizationEngine {
             final String fullRequest = objectWriter().writeValueAsString(request);
 
             LOG.debug(
-                    "Making a request ({}, {}) of length {} through the JNI interface:",
+                    "Making a request ({}) of length {} through the JNI interface:",
                     operation,
                     fullRequest.length());
             LOG.trace("The request:\n{}", fullRequest);


### PR DESCRIPTION
No matching issue

Removed superfluous log statement template placeholder that causes an IllegalArgumentException from BasicAuthorizationEngine::call. It appears that the full request log was moved to the subsequent LOG.trace statement, but the corresponding placeholder in this line was not removed. In the latest release available in the MavenCentral repository (2.4.3), this can cause authorization requests to fail if the log level is debug or lower.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
