### PR TITLE
Add check that javadocs build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Cargo Build & Test
+name: Build & Test (CedarJava & CedarJavaFFI)
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
         toolchain:
           - stable
     steps:
-      - name: Checkout Cedar Examples
+      - name: Checkout CedarJava
         uses: actions/checkout@v3
       - name: Checkout cedar
         uses: actions/checkout@v3
@@ -37,8 +37,12 @@ jobs:
         run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - name: cargo test
         working-directory: ./CedarJavaFFI
-        run: cargo test --verbose
-      - name: Build CedarJava
+        run: RUSTFLAGS="-D warnings -F unsafe-code" cargo test --verbose
+      - name: Build and Test CedarJava
         working-directory: ./CedarJava
         shell: bash
         run: export MUST_RUN_CEDAR_INTEGRATION_TESTS=1 && ./gradlew build
+      - name: JavaDoc Cedarjava
+        working-directory: ./CedarJava
+        shell: bash
+        run: ./gradlew javadoc

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/Entity.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/Entity.java
@@ -42,7 +42,7 @@ public class Entity {
      *
      * @param uid EUID of the Entity.
      * @param attributes Key/Value map of attributes.
-     * @param parentsEUID Set of parent entities' EUIDs.
+     * @param parentsEUIDs Set of parent entities' EUIDs.
      */
     public Entity(EntityUID uid, Map<String, Value> attributes, Set<EntityUID> parentsEUIDs) {
         this.attrs = new HashMap<>(attributes);


### PR DESCRIPTION
Fix one error reported by `./gradlew javadoc`. Other workflow tweaks (change names, use same flags for cargo build and test to save a bit of build time)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
