### PR TITLE
Update BasicAuthorizationEngine.java to fix logger error

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
@@ -92,7 +92,7 @@ public final class BasicAuthorizationEngine implements AuthorizationEngine {
             final String fullRequest = objectWriter().writeValueAsString(request);
 
             LOG.debug(
-                    "Making a request ({}, {}) of length {} through the JNI interface:",
+                    "Making a request ({}) of length {} through the JNI interface:",
                     operation,
                     fullRequest.length());
             LOG.trace("The request:\n{}", fullRequest);


### PR DESCRIPTION
No matching issue

Removed superfluous log statement template placeholder that causes an IllegalArgumentException from BasicAuthorizationEngine::call. It appears that the full request log was moved to the subsequent LOG.trace statement, but the corresponding placeholder in this line was not removed. This can cause authorization requests to fail if the log level is debug or lower. This fix is the same as [PR #90 ](https://github.com/cedar-policy/cedar-java/pull/90), but targets the main branch instead of the current MavenCentral release branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
