### PR TITLE
Add Gradle tasks for bundling native libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,47 +2,30 @@ name: Build & Test (CedarJava & CedarJavaFFI)
 
 on:
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_and_test_cedar_java_ffi:
-    name: Rust project - latest
+  build:
+    name: Build FFI and Java
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
     steps:
-      - name: Checkout CedarJava
-        uses: actions/checkout@v3
-      - name: Checkout cedar
-        uses: actions/checkout@v3
-        with:
-          repository: cedar-policy/cedar
-          ref: main
-          path: ./cedar
-      - name: rustup
-        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: cargo fmt
+      - name: Checkout cedar-java
+        uses: actions/checkout@v4
+      - name: Prepare Rust Build
+        run: rustup update stable && rustup default stable
+      - name: Check FFI Formatting
         working-directory: ./CedarJavaFFI
         run: cargo fmt --all --check
-      - name: configure
+      - name: Install Zig
+        run: sudo snap install zig --beta --classic
+      - name: Build FFI and Java Libraries
         working-directory: ./CedarJava
-        shell: bash
-        run: bash config.sh run_int_tests
-      - name: cargo build
-        working-directory: ./CedarJavaFFI
-        run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
-      - name: cargo test
-        working-directory: ./CedarJavaFFI
-        run: RUSTFLAGS="-D warnings -F unsafe-code" cargo test --verbose
-      - name: Build and Test CedarJava
+        env:
+          MUST_RUN_CEDAR_INTEGRATION_TESTS: 1
+        run: ./gradlew build
+      - name: Generate Java Documentation
         working-directory: ./CedarJava
-        shell: bash
-        run: export MUST_RUN_CEDAR_INTEGRATION_TESTS=1 && ./gradlew build
-      - name: JavaDoc Cedarjava
-        working-directory: ./CedarJava
-        shell: bash
         run: ./gradlew javadoc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+.gradle/
+.idea/
+/build
+/buildSrc/build/
+/gradle/
+/gradlew
+/gradlew.bat
+/wrapper/
+.DS_Store
+.jqwik-database
+*.iml
+.classpath
+.factorypath
+.project
+.settings/
+target/
+
+# Ignore changes to gradle.properties because we enter passwords here for releases
+/gradle.properties

--- a/CedarJava/README.md
+++ b/CedarJava/README.md
@@ -4,44 +4,33 @@ This package provides the Java interface for the Cedar language. You can use the
 
 For more information about Cedar, please see: https://www.cedarpolicy.com/
 
-## Usage
-This package depends on [Cedar](https://www.cedarpolicy.com/), a library
-that needs to be compiled so that it can be run on the used platform.
-You need JDK 17 or later to run the code.
+## Prerequisites
 
-You need to ensure the `CEDAR_JAVA_FFI_LIB` variable is set correctly. Typically ./config.sh will set this for you.
+- [JDK 17](https://openjdk.org/projects/jdk/17/) or later
+- [Rust](https://rustup.rs/) with `rustup`
+- [Zig](https://ziglang.org/learn/getting-started/) for cross compiling with [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild)
 
-### Building
-- Ensure Rust, Gradle and a JDK are installed.
-- then:
+## Building
+
+Run the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper_basics.html)
+with the `build` task to compile both the Cedar Java Foreign Function Interface and the Cedar Java library.
+
 ```shell
-cd CedarJavaFFI
-cargo build
-cargo test
-cd ../CedarJava
-bash config.sh
 ./gradlew build
 ```
-This will run the tests as well (but not the integration tests).
 
-If you want to run the integration tests, you'll also need:
+## Integration Testing
+
+Set the `CEDAR_INTEGRATION_TESTS_ROOT` environment variable to enable integration tests when building.
+
 ```shell
 export CEDAR_INTEGRATION_TESTS_ROOT=`path_to_cedar/cedar-integration-tests`
 ```
 
-Otherwise you can do (done for you in `config.sh`):
-```shell
-export CEDAR_INTEGRATION_TESTS_ROOT=`/tmp`
-```
-And the tests won't be found (and hence won't be run).
-
-
 ## Debugging
 
 If you're encountering unexpected errors, a good first step in debugging can be to enable TRACE-level logging for
-`cedarpolicy`, which will then show the exact messages being passed to Cedar. You can do this for
-the unit tests by modifying the `test/resources/log4j2.xml` file; this file also gives an example for what to do in
-other Log4j2-based packages.
+`com.cedarpolicy`, which will then show the exact messages being passed to Cedar.
 
 Debugging calls across the JNI boundary is a bit tricky (as ever a bit more so on a Mac), but can be done by attaching
 both a Java and native debugger (such as GDB/LLDB) to the program.

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14"
+    classpath "com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.8"
     classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.9"
   }
 }
@@ -21,6 +21,9 @@ plugins {
     // JaCoCo for coverage metrics and reports of Java source files. Read more at:
     // https://docs.gradle.org/current/userguide/jacoco_plugin.html
     id 'jacoco'
+
+    // Maven Publish for publishing artifacts to an Apache Maven repository
+    id 'maven-publish'
 }
 
 /*
@@ -70,6 +73,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.2'
     implementation 'org.slf4j:slf4j-api:2.0.12'
+    implementation 'com.fizzed:jne:4.1.1'
     implementation 'com.google.guava:guava:33.0.0-jre'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.3'
     testImplementation 'org.slf4j:slf4j-simple:2.0.12'
@@ -84,5 +88,156 @@ test {
     testLogging {
         showStandardStreams false
         exceptionFormat 'full'
+    }
+}
+
+def ffiDir = '../CedarJavaFFI'
+def compiledLibDir = 'resources/compiled'
+
+def rustLibraryTargets = [
+        'aarch64-apple-darwin' : 'libcedar_java_ffi.dylib',
+        'aarch64-unknown-linux-gnu' : 'libcedar_java_ffi.so',
+        'x86_64-apple-darwin' : 'libcedar_java_ffi.dylib',
+        'x86_64-pc-windows-gnu' : 'cedar_java_ffi.dll',
+        'x86_64-unknown-linux-gnu' : 'libcedar_java_ffi.so'
+]
+
+def rustJavaTargets = [
+        'aarch64-apple-darwin' : 'macos/aarch64',
+        'aarch64-unknown-linux-gnu' : 'linux/aarch64',
+        'x86_64-apple-darwin' : 'macos/x86_64',
+        'x86_64-pc-windows-gnu' : 'windows/x86_64',
+        'x86_64-unknown-linux-gnu' : 'linux/x86_64'
+]
+
+tasks.register('installCargoZigbuild', Exec) {
+    group 'Build'
+    description 'Installs Cargo Zigbuild for Rust compilation.'
+
+    commandLine 'cargo', 'install', 'cargo-zigbuild'
+}
+
+tasks.register('installRustTargets') {
+    dependsOn('installCargoZigbuild')
+    group 'Build'
+    description 'Installs Rust platform build targets.'
+
+    doLast {
+        rustLibraryTargets.keySet().forEach { rustTarget ->
+            exec {
+                commandLine 'rustup', 'target', 'add', rustTarget
+            }
+        }
+    }
+}
+
+tasks.register('compileFFI') {
+    dependsOn('installRustTargets')
+    group 'Build'
+    description 'Compiles Foreign Function Interface libraries.'
+
+    doLast {
+        rustLibraryTargets.forEach { rustTarget, libraryFile ->
+            exec {
+                workingDir = ffiDir
+                commandLine 'cargo', 'zigbuild', '--release', '--target', rustTarget
+            }
+
+            def sourcePath = "${ffiDir}/target/${rustTarget}/release/${libraryFile}"
+            def javaTargetPath = rustJavaTargets.get(rustTarget)
+
+            copy {
+                from(sourcePath)
+                into layout.buildDirectory.dir("${compiledLibDir}/jne/${javaTargetPath}")
+            }
+        }
+    }
+}
+
+tasks.register('testFFI') {
+    dependsOn('compileFFI')
+    group 'Build'
+    description 'Tests Foreign Function Interface libraries.'
+
+    doLast {
+        exec {
+            workingDir = ffiDir
+            commandLine 'cargo', 'test'
+        }
+    }
+}
+
+tasks.register('cleanFFI', Exec) {
+    group 'Build'
+    description 'Deletes the build directory for Foreign Function Interface libraries.'
+
+    workingDir ffiDir
+    commandLine 'cargo', 'clean'
+}
+
+tasks.register('uberJar', Jar) {
+    dependsOn('compileFFI')
+    group 'Build'
+    description 'Assembles a jar archive containing standard classes and native libraries.'
+
+    archiveClassifier = 'uber'
+    with jar
+
+    from(layout.buildDirectory.dir(compiledLibDir))
+}
+
+tasks.named('test') {
+    dependsOn('compileFFI')
+    classpath += files(layout.buildDirectory.dir(compiledLibDir))
+}
+
+tasks.named('build') {
+    dependsOn('uberJar')
+}
+
+/*
+ Configures Maven publishing
+ */
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'com.cedarpolicy'
+            artifactId = 'cedar-java'
+            version = '3.1.0-SNAPSHOT'
+
+            from components.java
+
+            artifacts {
+                jar
+                artifact tasks.named('uberJar')
+            }
+
+            pom {
+                name = 'cedar-java'
+                description = 'Java bindings for Cedar policy language.'
+                url = 'http://www.cedarpolicy.com'
+
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'cedar'
+                        name = 'Cedar Team'
+                        email = 'cedar-sonatype-team@amazon.com'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:https://github.com/cedar-policy/cedar-java.git'
+                    developerConnection = 'scm:git:https://github.com/cedar-policy/cedar-java.git'
+                    url = 'https://github.com/cedar-policy/cedar-java'
+                }
+            }
+        }
     }
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
@@ -21,6 +21,7 @@ import static com.cedarpolicy.CedarJson.objectWriter;
 
 import java.io.IOException;
 
+import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.model.*;
 import com.cedarpolicy.model.exception.AuthException;
 import com.cedarpolicy.model.exception.BadRequestException;
@@ -40,7 +41,7 @@ public final class BasicAuthorizationEngine implements AuthorizationEngine {
     private static final Logger LOG = LoggerFactory.getLogger(BasicAuthorizationEngine.class);
 
     static {
-        System.load(System.getenv("CEDAR_JAVA_FFI_LIB"));
+        LibraryLoader.loadLibrary();
     }
 
     /** Construct a basic authorization engine. */

--- a/CedarJava/src/main/java/com/cedarpolicy/loader/LibraryLoader.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/loader/LibraryLoader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cedarpolicy.loader;
+
+import com.fizzed.jne.JNE;
+
+/**
+ * Native Library Loader encapsulates runtime loading of the Cedar Java FFI library
+ */
+public class LibraryLoader {
+    private static final String LIBRARY_PATH_VARIABLE_NAME = "CEDAR_JAVA_FFI_LIB";
+
+    private static final String LIBRARY_NAME = "cedar_java_ffi";
+
+    /**
+     * Load Cedar Java FFI library based on runtime operating system and architecture of the Java Virtual Machine
+     */
+    public static void loadLibrary() {
+        final String libraryPath = System.getenv(LIBRARY_PATH_VARIABLE_NAME);
+        if (libraryPath == null || libraryPath.isEmpty()) {
+            JNE.loadLibrary(LIBRARY_NAME);
+        } else {
+            System.load(libraryPath);
+        }
+    }
+}

--- a/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
@@ -16,6 +16,7 @@
 
 package com.cedarpolicy.model.schema;
 
+import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.model.exception.InternalException;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,7 +30,7 @@ public final class Schema {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     static {
-        System.load(System.getenv("CEDAR_JAVA_FFI_LIB"));
+        LibraryLoader.loadLibrary();
     }
 
     // The schema after being parsed as a JSON object.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/Policy.java
@@ -16,9 +16,11 @@
 
 package com.cedarpolicy.model.slice;
 
+import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.model.exception.InternalException;
 import com.cedarpolicy.value.EntityUID;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +33,7 @@ public class Policy {
     private static final Logger LOG = LoggerFactory.getLogger(Policy.class);
     private static final AtomicInteger idCounter = new AtomicInteger(0);
     static {
-        System.load(System.getenv("CEDAR_JAVA_FFI_LIB"));
+        LibraryLoader.loadLibrary();
     }
 
     /** Policy string. */
@@ -47,6 +49,7 @@ public class Policy {
      * @param policyID The id of this policy. Must be unique. Note: We may flip the order of the
      *     arguments here for idiomatic reasons.
      */
+    @SuppressFBWarnings
     public Policy(
             @JsonProperty("policySrc") String policy, @JsonProperty("policyID") String policyID)
             throws NullPointerException {

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/Policy.java
@@ -49,7 +49,7 @@ public class Policy {
      * @param policyID The id of this policy. Must be unique. Note: We may flip the order of the
      *     arguments here for idiomatic reasons.
      */
-    @SuppressFBWarnings
+    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     public Policy(
             @JsonProperty("policySrc") String policy, @JsonProperty("policyID") String policyID)
             throws NullPointerException {

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/JsonEUID.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/JsonEUID.java
@@ -57,7 +57,7 @@ public class JsonEUID {
         this.type = type; this.id = id;
     }
 
-    @SuppressFBWarnings
+    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     public JsonEUID(String src) throws InvalidEUIDException {
         var o = EntityUID.parse(src);
         if (o.isPresent()) {

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/JsonEUID.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/JsonEUID.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.cedarpolicy.value.EntityUID;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /** Represent JSON format of Entity Unique Identifier. */
 @JsonDeserialize
@@ -56,6 +57,7 @@ public class JsonEUID {
         this.type = type; this.id = id;
     }
 
+    @SuppressFBWarnings
     public JsonEUID(String src) throws InvalidEUIDException {
         var o = EntityUID.parse(src);
         if (o.isPresent()) {

--- a/CedarJava/src/main/java/com/cedarpolicy/value/Decimal.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/Decimal.java
@@ -52,7 +52,7 @@ public class Decimal extends Value {
      *
      * @param decimal Decimal as a String.
      */
-    @SuppressFBWarnings
+    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     public Decimal(String decimal) throws NullPointerException, IllegalArgumentException {
         if (!DecimalValidator.validDecimal(decimal)) {
             throw new IllegalArgumentException(

--- a/CedarJava/src/main/java/com/cedarpolicy/value/Decimal.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/Decimal.java
@@ -16,6 +16,7 @@
 
 package com.cedarpolicy.value;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -51,6 +52,7 @@ public class Decimal extends Value {
      *
      * @param decimal Decimal as a String.
      */
+    @SuppressFBWarnings
     public Decimal(String decimal) throws NullPointerException, IllegalArgumentException {
         if (!DecimalValidator.validDecimal(decimal)) {
             throw new IllegalArgumentException(

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityIdentifier.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityIdentifier.java
@@ -1,6 +1,8 @@
 package com.cedarpolicy.value;
 
 
+import com.cedarpolicy.loader.LibraryLoader;
+
 /**
  * Class representing Entity Identifiers.
  * All strings are valid Entity Identifiers
@@ -8,8 +10,8 @@ package com.cedarpolicy.value;
 public final class EntityIdentifier {
     private String id; 
 
-    static { 
-        System.load(System.getenv("CEDAR_JAVA_FFI_LIB"));
+    static {
+        LibraryLoader.loadLibrary();
     }
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityTypeName.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityTypeName.java
@@ -1,6 +1,7 @@
 
 package com.cedarpolicy.value;
 
+import com.cedarpolicy.loader.LibraryLoader;
 import com.google.common.base.Suppliers;
 
 import java.util.List;
@@ -22,7 +23,7 @@ public final class EntityTypeName {
     private final Supplier<String> entityTypeNameRepr;
 
     static {
-        System.load(System.getenv("CEDAR_JAVA_FFI_LIB"));
+        LibraryLoader.loadLibrary();
     }
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityUID.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityUID.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.serializer.JsonEUID;
 import com.google.common.base.Suppliers;
 
@@ -32,8 +33,8 @@ public final class EntityUID extends Value {
     private final EntityIdentifier id;
     private final Supplier<String> euidRepr;
 
-    static { 
-        System.load(System.getenv("CEDAR_JAVA_FFI_LIB"));
+    static {
+        LibraryLoader.loadLibrary();
     }
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/value/IpAddress.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/IpAddress.java
@@ -16,6 +16,7 @@
 
 package com.cedarpolicy.value;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,6 +79,7 @@ public class IpAddress extends Value {
      *
      * @param ipAddress IP address as a String.
      */
+    @SuppressFBWarnings
     public IpAddress(String ipAddress) throws NullPointerException, IllegalArgumentException {
         if (!IpAddressValidator.validIPv4(ipAddress) && !IpAddressValidator.validIPv6(ipAddress)) {
             throw new IllegalArgumentException(

--- a/CedarJava/src/main/java/com/cedarpolicy/value/IpAddress.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/IpAddress.java
@@ -79,7 +79,7 @@ public class IpAddress extends Value {
      *
      * @param ipAddress IP address as a String.
      */
-    @SuppressFBWarnings
+    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     public IpAddress(String ipAddress) throws NullPointerException, IllegalArgumentException {
         if (!IpAddressValidator.validIPv4(ipAddress) && !IpAddressValidator.validIPv6(ipAddress)) {
             throw new IllegalArgumentException(

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -58,6 +58,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -258,6 +259,7 @@ public class SharedIntegrationTests {
      * Generates a test container for all the test requests in a json file. Each request is its own
      * test, and all the test in the json file are grouped into the returned container.
      */
+    @SuppressFBWarnings
     private DynamicContainer loadJsonTests(String jsonFile) throws IOException {
         JsonTest test;
         try (InputStream jsonIn =

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -259,7 +259,7 @@ public class SharedIntegrationTests {
      * Generates a test container for all the test requests in a json file. Each request is its own
      * test, and all the test in the json file are grouped into the returned container.
      */
-    @SuppressFBWarnings
+    @SuppressFBWarnings("NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD")
     private DynamicContainer loadJsonTests(String jsonFile) throws IOException {
         JsonTest test;
         try (InputStream jsonIn =


### PR DESCRIPTION
*Issue #, if available:*

Issue #28

*Description of changes:*

# Summary

This pull request incorporates both code and build changes to provide an uber JAR that bundles the native Cedar Foreign Function Interface libraries required for JNI operations.

# Code Changes

The code changes consists of a new `LibraryLoader` class that introduces a shared method named `loadLibrary()` to handle native library loading. The `LibraryLoader.loadLibrary()` call replaces all instances of `System.load()`, maintaining the existing option to load the native library from a path specified in the `CEDAR_JAVA_FFI_LIB` environment variable.

When the `CEDAR_JAVA_FFI_LIB` environment variable in not specified, `LibraryLoader.loadLibrary()` delegates to the [Java Native Environment](https://github.com/fizzed/jne) `JNE.loadLibrary()` method, which detects the runtime architecture, copies the applicable library to a temporary directory, and calls the appropriate System method. JNE is licensed under Apache Software License 2.0 and provides a conventional approach to native library loading. The standard convention requires that native libraries be placed in a JAR under a `jne` directory with operating system and architecture sub-directories.

# Build Changes

The build changes consist of Gradle tasks that run Cargo build commands and copy native libraries to standard directories. The new Gradle `uberJar` task produces a JAR containing both the standard Java classes and native libraries for the following targets:

- `aarch64-apple-darwin`
- `aarch64-unknown-linux-gnu`
- `x86_64-apple-darwin`
- `x86_64-pc-windows-gnu`
- `x86_64-unknown-linux-gnu`

These targets cover most common uses on Linux, macOS, and Windows for both [AArch64](https://en.wikipedia.org/wiki/AArch64) and [x86_64](https://en.wikipedia.org/wiki/X86-64).

The uber JAR is about 22 MB, which is significant, but provides broad compatibility and includes notable compression for the native libraries binaries.

The Gradle build continues to produce a standard JAR without any native libraries.

The Gradle build tasks use [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild) which depends on [Zig](https://ziglang.org/) for cross-compilation. This requires Zig to be installed in addition to Rust, but it enables compilation on either Linux or macOS regardless of version or architecture. This approach allows both local development and GitHub Runners to use the same Gradle tasks without conditional handling in the build configuration. 

The Gradle build updates add the [Maven Publish Plugin](https://docs.gradle.org/current/userguide/publishing_maven.html) to enable local builds using the `./gradlew publishToMavenLocal` command. The Maven configuration properties reflect the values published to Maven Central for [cedar-java](https://central.sonatype.com/artifact/com.cedarpolicy/cedar-java).

Additional changes include upgrading the SpotBugs build plugin from 5.0.14 to 6.0.8 and adding several `SuppressFBWarnings` annotations required as the result of new SpotBugs rules.

# Additional Steps

The goal of this pull request is to introduce support for building a JAR that includes native libraries. Subsequent changes may be required for publishing the new uber JAR to Maven Central with the `uber` classifier.

Next steps could also include building JARs scoped a specific architecture or operating system. However, for projects planning to build and deploy across different platforms, the uber JAR is likely to be the most useful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
