### PR TITLE
Remove direct use of SLF4J logging

### DIFF
--- a/CedarJava/README.md
+++ b/CedarJava/README.md
@@ -29,9 +29,6 @@ export CEDAR_INTEGRATION_TESTS_ROOT=`path_to_cedar/cedar-integration-tests`
 
 ## Debugging
 
-If you're encountering unexpected errors, a good first step in debugging can be to enable TRACE-level logging for
-`com.cedarpolicy`, which will then show the exact messages being passed to Cedar.
-
 Debugging calls across the JNI boundary is a bit tricky (as ever a bit more so on a Mac), but can be done by attaching
 both a Java and native debugger (such as GDB/LLDB) to the program.
 

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -72,11 +72,9 @@ dependencies {
     // The upgrade should be reviewed by AppSec
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.2'
-    implementation 'org.slf4j:slf4j-api:2.0.12'
     implementation 'com.fizzed:jne:4.1.1'
     implementation 'com.google.guava:guava:33.1.0-jre'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.3'
-    testImplementation 'org.slf4j:slf4j-simple:2.0.12'
     testImplementation 'net.jqwik:jqwik:1.8.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'

--- a/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
@@ -33,13 +33,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** An authorization engine that is compiled in process. Communicated with via JNI. */
 public final class BasicAuthorizationEngine implements AuthorizationEngine {
-    private static final Logger LOG = LoggerFactory.getLogger(BasicAuthorizationEngine.class);
-
     static {
         LibraryLoader.loadLibrary();
     }
@@ -50,7 +46,6 @@ public final class BasicAuthorizationEngine implements AuthorizationEngine {
     @Override
     public AuthorizationResponse isAuthorized(com.cedarpolicy.model.AuthorizationRequest q, Slice slice)
             throws AuthException {
-        LOG.trace("Making an isAuthorized request:\n{}\nwith slice\n{}", q, slice);
         final AuthorizationRequest request = new AuthorizationRequest(q, slice);
         return call("AuthorizationOperation", AuthorizationResponse.class, request);
     }
@@ -60,7 +55,6 @@ public final class BasicAuthorizationEngine implements AuthorizationEngine {
     public PartialAuthorizationResponse isAuthorizedPartial(com.cedarpolicy.model.PartialAuthorizationRequest q, Slice slice)
             throws AuthException {
         try {
-            LOG.trace("Making an isAuthorizedPartial request:\n{}\nwith slice\n{}", q, slice);
             final PartialAuthorizationRequest request = new PartialAuthorizationRequest(q, slice);
             return call("AuthorizationPartialOperation", PartialAuthorizationResponse.class, request);
         }
@@ -75,7 +69,6 @@ public final class BasicAuthorizationEngine implements AuthorizationEngine {
 
     @Override
     public ValidationResponse validate(ValidationRequest q) throws AuthException {
-        LOG.trace("Making a validate request:\n{}", q);
         return call("ValidateOperation", ValidationResponse.class, q);
     }
 
@@ -92,14 +85,7 @@ public final class BasicAuthorizationEngine implements AuthorizationEngine {
             }
             final String fullRequest = objectWriter().writeValueAsString(request);
 
-            LOG.debug(
-                    "Making a request ({}) of length {} through the JNI interface:",
-                    operation,
-                    fullRequest.length());
-            LOG.trace("The request:\n{}", fullRequest);
-
             final String response = callCedarJNI(operation, fullRequest);
-            LOG.trace("Received response of length {}:\n{}", response.length(), response);
 
             final JsonNode responseNode = objectReader().readTree(response);
             boolean wasSuccessful = responseNode.path("success").asBoolean(false);

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/Policy.java
@@ -21,16 +21,12 @@ import com.cedarpolicy.model.exception.InternalException;
 import com.cedarpolicy.value.EntityUID;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 
 /** Policies in the Cedar language. */
 public class Policy {
-    private static final Logger LOG = LoggerFactory.getLogger(Policy.class);
     private static final AtomicInteger idCounter = new AtomicInteger(0);
     static {
         LibraryLoader.loadLibrary();


### PR DESCRIPTION
*Issue #, if available:* #95

*Description of changes:*

This pull request removes direct references to SLF4J logging from all classes. The `Policy` class had an unused logger, leaving the `BasicAuthorizationEngine` class as the only runtime usage at the `TRACE` level.

It is important to note that the `com.fizzed:jne` library has a dependency on `slf4j-api`, but that could be evaluated separately.