### PR TITLE
Update Gradle build to download integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build & Test (CedarJava & CedarJavaFFI)
+name: Continuous Integration Build
 
 on:
   pull_request:
@@ -9,30 +9,37 @@ env:
 
 jobs:
   build:
-    name: Build FFI and Java
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
+        include:
+          - os: ubuntu-latest
+            name: Build on Linux
+            zigInstall: sudo snap install zig --beta --classic
+          - os: macos-14
+            name: Build on macOS
+            zigInstall: brew install zig
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
     steps:
       - name: Checkout cedar-java
         uses: actions/checkout@v4
-      - name: Checkout cedar
-        uses: actions/checkout@v4
-        with:
-          repository: cedar-policy/cedar
-          ref: main
-          path: /home/runner/work/cedar-java/cedar-java/cedar
       - name: Prepare Rust Build
         run: rustup update stable && rustup default stable
       - name: Check FFI Formatting
-        working-directory: ./CedarJavaFFI
+        working-directory: CedarJavaFFI
         run: cargo fmt --all --check
       - name: Install Zig
-        run: sudo snap install zig --beta --classic
+        run: ${{ matrix.zigInstall }}
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: 'gradle'
       - name: Build FFI and Java Libraries
-        working-directory: ./CedarJava
-        env:
-          MUST_RUN_CEDAR_INTEGRATION_TESTS: 1
-          CEDAR_INTEGRATION_TESTS_ROOT: /home/runner/work/cedar-java/cedar-java/cedar/cedar-integration-tests
+        working-directory: CedarJava
         run: ./gradlew build
       - name: Generate Java Documentation
-        working-directory: ./CedarJava
+        working-directory: CedarJava
         run: ./gradlew javadoc

--- a/CedarJava/README.md
+++ b/CedarJava/README.md
@@ -19,14 +19,6 @@ with the `build` task to compile both the Cedar Java Foreign Function Interface 
 ./gradlew build
 ```
 
-## Integration Testing
-
-Set the `CEDAR_INTEGRATION_TESTS_ROOT` environment variable to enable integration tests when building.
-
-```shell
-export CEDAR_INTEGRATION_TESTS_ROOT=`path_to_cedar/cedar-integration-tests`
-```
-
 ## Debugging
 
 If you're encountering unexpected errors, a good first step in debugging can be to enable TRACE-level logging for

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -24,6 +24,9 @@ plugins {
 
     // Maven Publish for publishing artifacts to an Apache Maven repository
     id 'maven-publish'
+
+    // Download Task for integration tests
+    id 'de.undercouch.download' version '5.6.0'
 }
 
 /*
@@ -177,9 +180,28 @@ tasks.register('uberJar', Jar) {
     from(layout.buildDirectory.dir(compiledLibDir))
 }
 
+tasks.register('downloadIntegrationTests', Download) {
+    group 'Build'
+    description 'Downloads Cedar repository with integration tests.'
+
+    src 'https://codeload.github.com/cedar-policy/cedar/zip/main'
+    dest layout.buildDirectory.file('cedar-main.zip')
+    overwrite false
+}
+
+tasks.register('extractIntegrationTests', Copy) {
+    group 'Build'
+    description 'Extracts Cedar integration tests.'
+
+    dependsOn('downloadIntegrationTests')
+    from zipTree(layout.buildDirectory.file('cedar-main.zip'))
+    into layout.buildDirectory.dir('resources/test')
+}
+
 tasks.named('test') {
     useJUnitPlatform()
     dependsOn('compileFFI')
+    dependsOn('extractIntegrationTests')
     classpath += files(layout.buildDirectory.dir(compiledLibDir))
 }
 

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -45,6 +45,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,7 +54,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -66,11 +66,6 @@ import org.junit.jupiter.api.TestFactory;
 /** Integration tests Used by Cedar / corpus tests saved from the fuzzer. */
 public class SharedIntegrationTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final String CEDAR_INTEGRATION_TESTS_ROOT =
-            Objects.requireNonNull(
-                    System.getenv("CEDAR_INTEGRATION_TESTS_ROOT"),
-                    "Environment variable CEDAR_INTEGRATION_TESTS_ROOT is required "
-                            + "for shared integration tests but is not present.");
 
     /**
      * For relative paths, return an absolute path rooted in the shared integration test root. For
@@ -81,10 +76,12 @@ public class SharedIntegrationTests {
      * @return A Path object containing an absolute path.
      */
     private Path resolveIntegrationTestPath(String path) {
-        if (Paths.get(path).isAbsolute()) {
-            return Paths.get(path);
+        final Path resolved = Paths.get(path);
+        if (resolved.isAbsolute()) {
+            return resolved;
         } else {
-            return Paths.get(CEDAR_INTEGRATION_TESTS_ROOT, path);
+            final URL integrationTestsLocation = getClass().getResource("/cedar-main/cedar-integration-tests");
+            return integrationTestsLocation == null ? resolved : Paths.get(integrationTestsLocation.getPath(), path);
         }
     }
 
@@ -220,8 +217,7 @@ public class SharedIntegrationTests {
     public List<DynamicContainer> integrationTestsFromJson() throws IOException {
         List<DynamicContainer> tests = new ArrayList<>();
         //If we can't find the `cedar` package, don't try to load integration tests.
-        //In CI, MUST_RUN_CEDAR_INTEGRATION_TESTS is set
-        if(System.getenv("MUST_RUN_CEDAR_INTEGRATION_TESTS") == null && Files.notExists(Paths.get(CEDAR_INTEGRATION_TESTS_ROOT, "corpus_tests"))) {
+        if (Files.notExists(resolveIntegrationTestPath("corpus_tests"))) {
             return tests;
         }
         // tests other than corpus tests
@@ -230,7 +226,7 @@ public class SharedIntegrationTests {
         }
         // corpus tests
        try (Stream<Path> stream =
-               Files.list(Paths.get(CEDAR_INTEGRATION_TESTS_ROOT, "corpus_tests"))) {
+               Files.list(resolveIntegrationTestPath("corpus_tests"))) {
            stream
                    // ignore non-JSON files
                    .filter(path -> path.getFileName().toString().endsWith(".json"))

--- a/README.md
+++ b/README.md
@@ -5,21 +5,19 @@ It also contains source code for a Rust crate `CedarJavaFFI` that enables callin
 
 
 ## Getting Started
-You can find detailed build instructions and more information in the subfolders [CedarJavaFFI](https://github.com/cedar-policy/cedar-java/blob/main/CedarJavaFFI/README.md), [CedarJava](https://github.com/cedar-policy/cedar-java/blob/main/CedarJava/README.md).
 
-For typical use, you'll want something like:
+The [CedarJavaFFI](https://github.com/cedar-policy/cedar-java/blob/main/CedarJavaFFI/README.md) and [CedarJava](https://github.com/cedar-policy/cedar-java/blob/main/CedarJava/README.md) directories contain detailed instructions on building individual modules.
+
+The `CedarJava` module uses Gradle to build both modules and run integration tests. The following commands provide general usage for getting started.
 
 ```shell
-cd CedarJavaFFI && cargo build
-cd ../CedarJava
-export CEDAR_INTEGRATION_TESTS_ROOT=/tmp #(assuming you don't want to run them)
-export CEDAR_JAVA_FFI_LIB=path_to_CedarJavaFFI/target/debug/libcedar_java_ffi.so #(or wherever you built CedarJavaFFI)
-gradle test
+cd CedarJava
+./gradlew build
 ```
 
 ## Notes
 
-You need JDK 17 or later to run the Java code.
+`CedarJava` requires JDK 17 or later.
 
 Cedar is primarily developed in Rust (in the [cedar](https://github.com/cedar-policy/cedar) repository). As such, `CedarJava` typically lags behind the newest Cedar features. Notably, as of this writing, `CedarJava` does not expose APIs for partial evaluation.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pull request updates the Gradle configuration to download the `main` branch of the Cedar repository, incorporating integration testing in the standard build. The [gradle-download-task](https://github.com/michel-kraemer/gradle-download-task) handles the HTTP request to the GitHub URL, downloading the Zip archive of the Cedar repository main branch.

Instead of setting the integration tests path from an environment variable, the Gradle tasks extract the Cedar repository archive to the build test resources directory. This approach makes the integration test corpus available as a class path resource. Updates to the `SharedIntegrationTests` class resolve the directory from the class path location.

Additional changes include updating the continuous integration workflow to run on both Ubuntu Linux and macOS 14. The macOS 14 runner uses AArch64 architecture. The updated workflow installs Zig using the platform-specific package manager, and also includes the [setup-java](https://github.com/actions/setup-java) action to provide a consistent vendor and version of the JDK.

