### PR TITLE
Removing Slice parameter from authorization APIs

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java
@@ -37,7 +37,7 @@ import java.util.Set;
  */
 public interface AuthorizationEngine {
     /**
-     * Asks whether the given AuthorizationRequest <code>q</code> is approved by the <code>policies</code> and
+     * Asks whether the given AuthorizationRequest <code>q</code> is approved by the <code>policySet</code> and
      * <code>entities</code> hierarchy given.
      *
      * @param request The request to evaluate
@@ -52,8 +52,8 @@ public interface AuthorizationEngine {
     AuthorizationResponse isAuthorized(AuthorizationRequest request, PolicySet policySet, Set<Entity> entities) throws AuthException;
 
     /**
-     * Asks whether the given AuthorizationRequest <code>q</code> is approved by the <code>policies</code> and
-     * <code>entities</code> given. If information required to answer is missing residual policies are returned.
+     * Asks whether the given AuthorizationRequest <code>q</code> is approved by the <code>policySet</code> and
+     * <code>entities</code> given. If information required to answer is missing, residual policies are returned.
      *
      * @param request The request to evaluate
      * @param policySet The policy set to evaluate against

--- a/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java
@@ -19,14 +19,17 @@ package com.cedarpolicy;
 import com.cedarpolicy.model.*;
 import com.cedarpolicy.model.exception.AuthException;
 import com.cedarpolicy.model.exception.BadRequestException;
-import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.model.slice.Entity;
+import com.cedarpolicy.model.slice.PolicySet;
+
+import java.util.Set;
 
 /**
  * Implementations of the AuthorizationEngine interface invoke Cedar to respond to an authorization
- * or validation request. For authorization, the input includes the relevant slice of the policy for
- * Cedar to consider. Clients can provide a slice in the form of Java objects constructed by the
+ * or validation request. For authorization, the input includes the relevant policies and entities for
+ * Cedar to consider. Clients can provide these inputs in the form of Java objects constructed by the
  * API, which will be converted to JSON internally. It is the client’s responsibility to ensure that
- * all relevant policy information is within the slice.
+ * all relevant policy information is given.
  *
  * <p>Note that Cedar does not have intrinsic limits on the sizes / number of policies. We could not
  * set such a limit as well as you, the user of the Cedar library. As such, it is your
@@ -34,26 +37,27 @@ import com.cedarpolicy.model.slice.Slice;
  */
 public interface AuthorizationEngine {
     /**
-     * Asks whether the given AuthorizationRequest <code>q</code> is approved by the policies and
-     * entity hierarchy given in the <code>slice</code>.
+     * Asks whether the given AuthorizationRequest <code>q</code> is approved by the <code>policies</code> and
+     * <code>entities</code> hierarchy given.
      *
      * @param request The request to evaluate
-     * @param slice The slice to evaluate against
+     * @param policySet The policy set to evaluate against
+     * @param entities The entities to evaluate against
      * @return The result of the request evaluation
      * @throws BadRequestException if any errors were found in the syntax of the policies.
      * @throws AuthException On failure to make the authorization request. Note that errors inside the
      *     authorization engine are included in the <code>errors</code> field on the
      *     AuthorizationResponse.
      */
-    AuthorizationResponse isAuthorized(AuthorizationRequest request, Slice slice) throws AuthException;
+    AuthorizationResponse isAuthorized(AuthorizationRequest request, PolicySet policySet, Set<Entity> entities) throws AuthException;
 
     /**
-     * Asks whether the given AuthorizationRequest <code>q</code> is approved by the policies and
-     * entity hierarchy given in the <code>slice</code>. If information required to answer is missing residual
-     * policies are returned.
+     * Asks whether the given AuthorizationRequest <code>q</code> is approved by the <code>policies</code> and
+     * <code>entities</code> given. If information required to answer is missing residual policies are returned.
      *
      * @param request The request to evaluate
-     * @param slice The slice to evaluate against
+     * @param policySet The policy set to evaluate against
+     * @param entities The entities to evaluate against
      * @return The result of the request evaluation
      * @throws BadRequestException if any errors were found in the syntax of the policies.
      * @throws AuthException On failure to make the authorization request. Note that errors inside the
@@ -61,7 +65,8 @@ public interface AuthorizationEngine {
      *     AuthorizationResponse.
      */
     @Experimental(ExperimentalFeature.PARTIAL_EVALUATION)
-    PartialAuthorizationResponse isAuthorizedPartial(PartialAuthorizationRequest request, Slice slice) throws AuthException;
+    PartialAuthorizationResponse isAuthorizedPartial(PartialAuthorizationRequest request,
+                                                     PolicySet policySet, Set<Entity> entities) throws AuthException;
 
     /**
      * Asks whether the policies in the given {@link ValidationRequest} <code>q</code> are correct

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationRequest.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 /**
  * An authorization request consists of a principal, action, and resource as well as a context mapping
- * strings to Cedar values. When evaluating the request against a slice, the authorization engine
+ * strings to Cedar values. When evaluating the request against a set of policies and entities, the authorization engine
  * determines if the policies allow for the given principal to perform the given action against the
  * given resource.
  *

--- a/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationRequest.java
@@ -15,11 +15,11 @@ import java.util.Optional;
 
 /**
  * A partial authorization request consists of an optional principal, action, and optional resource as well as an
- * optional context mapping strings to Cedar values. When evaluating the request against a slice, the authorization
- * engine determines if the policies allow for the given principal to perform the given action against the given
- * resource. If a decision can be reached, then the response will provide the decision. If a decision can't be reached
- * due to missing information Cedar will attempt to reduce the policies as much as possible and will return the residual
- * policies.
+ * optional context mapping strings to Cedar values. When evaluating the request against a set of policies and entities,
+ * the authorization engine determines if the policies allow for the given principal to perform the given action against
+ * the given resource. If a decision can be reached, then the response will provide the decision. If a decision can't be
+ * reached due to missing information Cedar will attempt to reduce the policies as much as possible and will return the
+ * residual policies.
  *
  * <p>If the (optional) schema is provided, this will inform parsing the
  * `context` from JSON: for instance, it will allow `__entity` and `__extn`

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/PolicySet.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/PolicySet.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cedarpolicy.model.slice;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/** Policy Set containing policies in the Cedar language. */
+public class PolicySet {
+
+    /** Policy set. */
+    public Set<Policy> policies;
+
+    /** Template Instantiations. */
+    public List<TemplateInstantiation> templateInstantiations;
+
+    /** Templates. */
+    public Set<Policy> templates;
+
+    public PolicySet() {
+        this.policies = Collections.emptySet();
+        this.templates = Collections.emptySet();
+        this.templateInstantiations = Collections.emptyList();
+    }
+
+    public PolicySet(Set<Policy> policies) {
+        this.policies = policies;
+        this.templates = Collections.emptySet();
+        this.templateInstantiations = Collections.emptyList();
+    }
+
+    public PolicySet(Set<Policy> policies, Set<Policy> templates, List<TemplateInstantiation> templateInstantiations) {
+        this.policies = policies;
+        this.templates = templates;
+        this.templateInstantiations = templateInstantiations;
+    }
+}

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -30,10 +30,9 @@ import com.cedarpolicy.model.AuthorizationSuccessResponse.Decision;
 import com.cedarpolicy.model.exception.AuthException;
 import com.cedarpolicy.model.exception.BadRequestException;
 import com.cedarpolicy.model.schema.Schema;
-import com.cedarpolicy.model.slice.BasicSlice;
 import com.cedarpolicy.model.slice.Entity;
 import com.cedarpolicy.model.slice.Policy;
-import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.model.slice.PolicySet;
 import com.cedarpolicy.value.EntityUID;
 import com.cedarpolicy.serializer.JsonEUID;
 import com.cedarpolicy.value.Value;
@@ -405,10 +404,10 @@ public class SharedIntegrationTests {
                     Optional.of(request.context),
                     Optional.of(schema),
                     request.validateRequest);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
 
         try {
-            final AuthorizationResponse response = auth.isAuthorized(authRequest, slice);
+            final AuthorizationResponse response = auth.isAuthorized(authRequest, policySet, entities);
             if (response.type == AuthorizationResponse.SuccessOrFailure.Success) {
                 final var success = assertDoesNotThrow(() -> response.success.get());
                 assertEquals(request.decision, success.getDecision());

--- a/CedarJava/src/test/java/com/cedarpolicy/pbt/IntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/pbt/IntegrationTests.java
@@ -567,9 +567,7 @@ public class IntegrationTests {
         ArrayList<TemplateInstantiation> templateInstantiations =
                 new ArrayList<TemplateInstantiation>(Arrays.asList(templateInstantiation));
 
-        PolicySet policySet = new PolicySet(policies);
-        policySet.templates = templates;
-        policySet.templateInstantiations = templateInstantiations;
+        PolicySet policySet = new PolicySet(policies, templates, templateInstantiations);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(

--- a/CedarJava/src/test/java/com/cedarpolicy/pbt/IntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/pbt/IntegrationTests.java
@@ -25,12 +25,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.cedarpolicy.BasicAuthorizationEngine;
 import com.cedarpolicy.model.AuthorizationRequest;
 import com.cedarpolicy.model.AuthorizationResponse;
-import com.cedarpolicy.model.slice.BasicSlice;
 import com.cedarpolicy.model.slice.Entity;
 import com.cedarpolicy.model.slice.EntityTypeAndId;
 import com.cedarpolicy.model.slice.Instantiation;
 import com.cedarpolicy.model.slice.Policy;
-import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.model.slice.PolicySet;
 import com.cedarpolicy.model.slice.TemplateInstantiation;
 import com.cedarpolicy.value.Decimal;
 import com.cedarpolicy.value.EntityUID;
@@ -66,9 +65,9 @@ public class IntegrationTests {
         resourceType = EntityTypeName.parse("Resource").get();
     }
 
-    private void assertAllowed(AuthorizationRequest request, Slice slice) {
+    private void assertAllowed(AuthorizationRequest request, PolicySet policySet, Set<Entity> entities) {
         assertDoesNotThrow(() -> {
-            final AuthorizationResponse response = ENGINE.isAuthorized(request, slice);
+            final AuthorizationResponse response = ENGINE.isAuthorized(request, policySet, entities);
             if (response.success.isPresent()) {
                 final var success = assertDoesNotThrow(() -> response.success.get());
                 assertTrue(success.isAllowed());
@@ -78,9 +77,9 @@ public class IntegrationTests {
         });
     }
 
-    private void assertNotAllowed(AuthorizationRequest request, Slice slice) {
+    private void assertNotAllowed(AuthorizationRequest request, PolicySet policySet, Set<Entity> entities) {
         assertDoesNotThrow(() -> {
-            final AuthorizationResponse response = ENGINE.isAuthorized(request, slice);
+            final AuthorizationResponse response = ENGINE.isAuthorized(request, policySet, entities);
             if (response.success.isPresent()) {
                 final var success = assertDoesNotThrow(() -> response.success.get());
                 assertFalse(success.isAllowed());
@@ -90,9 +89,9 @@ public class IntegrationTests {
         });
     }
 
-    private void assertFailure(AuthorizationRequest request, Slice slice) {
+    private void assertFailure(AuthorizationRequest request, PolicySet policySet, Set<Entity> entities) {
         assertDoesNotThrow(() -> {
-            final AuthorizationResponse response = ENGINE.isAuthorized(request, slice);
+            final AuthorizationResponse response = ENGINE.isAuthorized(request, policySet, entities);
             if (response.success.isPresent()) {
                 fail(String.format("Expected a failure, but got this success: %s", response.toString()));
             } else {
@@ -141,12 +140,12 @@ public class IntegrationTests {
         Policy policy = new Policy(p, "001");
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal.getEUID(), action.getEUID(), resource.getEUID(), currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
     /** Tests a randomly generated attribute for resource. */
@@ -209,12 +208,12 @@ public class IntegrationTests {
         Policy policy = new Policy(p, "ID" + count);
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
     /** Tests a randomly generated with one bad attribute for resource Response: Deny. */
@@ -284,12 +283,12 @@ public class IntegrationTests {
         Policy policy = new Policy(p, "ID" + count);
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertNotAllowed(request, slice);
+        assertNotAllowed(request, policySet, entities);
     }
 
     /** Tests a long expression that crashes the JNI if Rust doesn't spawn a new thread. */
@@ -319,12 +318,12 @@ public class IntegrationTests {
         Policy policy = new Policy(p, "ID1");
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
      /** Tests a long expression that is denied for nearing the stack overflow limit. */
@@ -353,12 +352,12 @@ public class IntegrationTests {
         Policy policy = new Policy(p, "ID1");
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertNotAllowed(request, slice);
+        assertNotAllowed(request, policySet, entities);
     }
 
     private String createNested(int repeats) {
@@ -398,7 +397,7 @@ public class IntegrationTests {
         Policy policy = new Policy(p, "001");
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
@@ -406,7 +405,7 @@ public class IntegrationTests {
                         action,
                         resource,
                         currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
     /** Test IpAddress extension. */
@@ -451,12 +450,12 @@ public class IntegrationTests {
         Policy policy = new Policy(p, policyId);
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
     /** Test Decimal extension. */
@@ -501,12 +500,12 @@ public class IntegrationTests {
         Policy policy = new Policy(p, policyId);
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
     /** Use template slots to tests a single attribute: resource.owner. */
@@ -568,12 +567,14 @@ public class IntegrationTests {
         ArrayList<TemplateInstantiation> templateInstantiations =
                 new ArrayList<TemplateInstantiation>(Arrays.asList(templateInstantiation));
 
-        Slice slice = new BasicSlice(policies, entities, templates, templateInstantiations);
+        PolicySet policySet = new PolicySet(policies);
+        policySet.templates = templates;
+        policySet.templateInstantiations = templateInstantiations;
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
     /** Test using schema parsing. */
@@ -622,7 +623,7 @@ public class IntegrationTests {
 
         // Schema says resource.owner is a bool, so we should get a parse failure, which causes
         // `isAuthorized()` to throw a `BadRequestException`.
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
@@ -632,7 +633,7 @@ public class IntegrationTests {
                         Optional.of(currentContext),
                         Optional.of(loadSchemaResource("/schema_parsing_deny_schema.json")),
                         true);
-        assertFailure(request, slice);
+        assertFailure(request, policySet, entities);
     }
 
     /** Test using schema parsing. */
@@ -681,7 +682,7 @@ public class IntegrationTests {
         policies.add(policy);
 
         // Schema says resource.owner is a User, so we should not get a parse failure.
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
@@ -691,6 +692,6 @@ public class IntegrationTests {
                         Optional.of(currentContext),
                         Optional.of(loadSchemaResource("/schema_parsing_allow_schema.json")),
                         true);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/pbt/ParserTest.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/pbt/ParserTest.java
@@ -19,10 +19,9 @@ package com.cedarpolicy.pbt;
 import com.cedarpolicy.BasicAuthorizationEngine;
 import com.cedarpolicy.model.AuthorizationRequest;
 import com.cedarpolicy.model.AuthorizationResponse;
-import com.cedarpolicy.model.slice.BasicSlice;
 import com.cedarpolicy.model.slice.Entity;
 import com.cedarpolicy.model.slice.Policy;
-import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.model.slice.PolicySet;
 import com.cedarpolicy.value.Value;
 import com.cedarpolicy.value.EntityIdentifier;
 import com.cedarpolicy.value.EntityTypeName;
@@ -54,9 +53,9 @@ public class ParserTest {
         resourceType = EntityTypeName.parse("Resource").get();
     }
 
-    private void assertAllowed(AuthorizationRequest request, Slice slice) {
+    private void assertAllowed(AuthorizationRequest request, PolicySet policySet, Set<Entity> entities) {
         assertDoesNotThrow(() -> {
-            final AuthorizationResponse response = new BasicAuthorizationEngine().isAuthorized(request, slice);
+            final AuthorizationResponse response = new BasicAuthorizationEngine().isAuthorized(request, policySet, entities);
             final var success = response.success.get();
             assertTrue(success.isAllowed());
         });
@@ -106,12 +105,12 @@ public class ParserTest {
         Policy policy = new Policy("permit(principal\n,action\n,resource\n);", ids);
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
     /**
@@ -170,12 +169,12 @@ public class ParserTest {
         Policy policy = new Policy(p, ids);
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
     }
 
     /*
@@ -227,7 +226,7 @@ public class ParserTest {
         Policy policy = new Policy(p, ids);
         Set<Policy> policies = new HashSet<>();
         policies.add(policy);
-        Slice slice = new BasicSlice(policies, entities);
+        PolicySet policySet = new PolicySet(policies);
         Map<String, Value> currentContext = new HashMap<>();
         AuthorizationRequest request =
                 new AuthorizationRequest(
@@ -235,7 +234,7 @@ public class ParserTest {
                         action,
                         resource,
                         currentContext);
-        assertAllowed(request, slice);
+        assertAllowed(request, policySet, entities);
 
         String actionList =
                 "[" + actions.stream().map(a -> a.getEUID().toString()).collect(Collectors.joining(",")) + "]";
@@ -255,13 +254,13 @@ public class ParserTest {
         Policy policy2 = new Policy(p2, ids);
         policies = new HashSet<>();
         policies.add(policy2);
-        Slice slice2 = new BasicSlice(policies, entities);
+        PolicySet policySet2 = new PolicySet(policies);
         Map<String, Value> currentContext2 = new HashMap<>();
         int index = Arbitraries.integers().between(0, actions.size() - 1).sample();
         action = actions.get(index);
         AuthorizationRequest request2 =
                 new AuthorizationRequest(
                         principal, action, resource, currentContext2);
-        assertAllowed(request2, slice2);
+        assertAllowed(request2, policySet2, entities);
     }
 }


### PR DESCRIPTION
https://github.com/cedar-policy/cedar-java/issues/40

Removing the Slice parameter from the [isAuthorized](https://github.com/mark-creamer-amazon/cedar-java/blob/main/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java#L52) and [isAuthorizedPartial](https://github.com/mark-creamer-amazon/cedar-java/blob/main/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java#L68C34-L68C53) method signatures, replacing with a `Set<Entity>` and a new object `PolicySet` which mirrors Rust's [PolicySet](https://github.com/cedar-policy/cedar/blob/b68be932492c8c8038d722962a950835ad58cfcd/cedar-policy/src/api.rs#L1585) (however without the convenient helper methods currently).

 We cannot get rid of the `Slice` object entirely until the [AuthorizationCall](https://github.com/cedar-policy/cedar/blob/main/cedar-policy/src/ffi/is_authorized.rs#L463-L485) struct in `cedar-policy/src/ffi` no longer specifies the `slice` field. See https://github.com/cedar-policy/cedar/issues/757

