### PR TITLE
use custom serializers for `Entity` and `Schema`

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/CedarJson.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/CedarJson.java
@@ -16,7 +16,11 @@
 
 package com.cedarpolicy;
 
+import com.cedarpolicy.model.entity.Entity;
+import com.cedarpolicy.model.schema.Schema;
 import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.serializer.EntitySerializer;
+import com.cedarpolicy.serializer.SchemaSerializer;
 import com.cedarpolicy.serializer.SliceSerializer;
 import com.cedarpolicy.serializer.ValueDeserializer;
 import com.cedarpolicy.serializer.ValueSerializer;
@@ -50,6 +54,8 @@ final class CedarJson {
         final ObjectMapper mapper = new ObjectMapper();
 
         final SimpleModule module = new SimpleModule();
+        module.addSerializer(Entity.class, new EntitySerializer());
+        module.addSerializer(Schema.class, new SchemaSerializer());
         module.addSerializer(Slice.class, new SliceSerializer());
         module.addSerializer(Value.class, new ValueSerializer());
         module.addDeserializer(Value.class, new ValueDeserializer());

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -60,6 +60,20 @@ public class Policy {
         this.policyID = policyID;
     }
 
+    /**
+     * Get the policy ID.
+     */
+    public String getID() {
+        return policyID;
+    }
+
+    /**
+     * Get the policy source.
+     */
+    public String getSource() {
+        return policySrc;
+    }
+
     @Override
     public String toString() {
         return "// Policy ID: " + policyID + "\n" + policySrc;

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
@@ -22,8 +22,9 @@ import com.cedarpolicy.model.exception.InternalException;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-
+import java.util.stream.Collectors;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -65,6 +66,24 @@ public class PolicySet {
         this.policies = policies;
         this.templates = templates;
         this.templateLinks = templateLinks;
+    }
+
+    /**
+     * Get the static policies in the policy set.
+     *
+     * @return A map from policy id to `Policy` object
+     */
+    public Map<String, String> getStaticPolicies() {
+        return policies.stream().collect(Collectors.toMap(Policy::getID, Policy::getSource));
+    }
+
+    /**
+     * Get the templates in the policy set.
+     *
+     * @return A map from policy id to `Policy` object
+     */
+    public Map<String, String> getTemplates() {
+        return templates.stream().collect(Collectors.toMap(Policy::getID, Policy::getSource));
     }
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
@@ -18,10 +18,8 @@ package com.cedarpolicy.model.schema;
 
 import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.model.exception.InternalException;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.Optional;
@@ -36,13 +34,12 @@ public final class Schema {
     }
 
     /** Is this schema in the JSON or human format */
-    @JsonIgnore
     public final JsonOrHuman type;
+
     /** This will be present if and only if `type` is `Json`. */
-    @JsonProperty("json")
-    private final Optional<JsonNode> schemaJson;
+    public final Optional<JsonNode> schemaJson;
+
     /** This will be present if and only if `type` is `Human`. */
-    @JsonProperty("human")
     public final Optional<String> schemaText;
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/model/slice/BasicSlice.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/slice/BasicSlice.java
@@ -20,7 +20,6 @@ import com.cedarpolicy.model.entity.Entity;
 import com.cedarpolicy.model.policy.Policy;
 import com.cedarpolicy.model.policy.TemplateLink;
 import com.cedarpolicy.value.Value;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.*;
@@ -37,10 +36,8 @@ public class BasicSlice implements Slice {
 
     private final Set<Entity> entities;
 
-    @JsonProperty("templatePolicies")
     private final Map<String, String> templatePolicies;
 
-    @JsonProperty("templateInstantiations")
     private final List<TemplateLink> templateLinks;
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/EntitySerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/EntitySerializer.java
@@ -16,26 +16,27 @@
 
 package com.cedarpolicy.serializer;
 
-import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.model.entity.Entity;
+import com.cedarpolicy.value.EntityUID;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
+import java.util.stream.Collectors;
 
-/** Serialize a slice. Only used internally by CedarJson */
-public class SliceSerializer extends JsonSerializer<Slice> {
+/** Serialize an entity. */
+public class EntitySerializer extends JsonSerializer<Entity> {
 
-    /** Serialize a slice. */
+    /** Serialize an entity. */
     @Override
     public void serialize(
-            Slice slice, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            Entity entity, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
             throws IOException {
         jsonGenerator.writeStartObject();
-        jsonGenerator.writeObjectField("policies", slice.getPolicies());
-        jsonGenerator.writeObjectField("entities", slice.getEntities());
-        jsonGenerator.writeObjectField("templates", slice.getTemplates());
-        jsonGenerator.writeObjectField(
-                "templateInstantiations", slice.getTemplateLinks());
+        jsonGenerator.writeObjectField("uid", entity.getEUID().asJson());
+        jsonGenerator.writeObjectField("attrs", entity.attrs);
+        jsonGenerator.writeObjectField("parents",
+                entity.getParents().stream().map(EntityUID::asJson).collect(Collectors.toSet()));
         jsonGenerator.writeEndObject();
     }
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/JsonEUID.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/JsonEUID.java
@@ -20,14 +20,10 @@ import com.cedarpolicy.model.exception.InvalidEUIDException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.cedarpolicy.value.EntityUID;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /** Represent JSON format of Entity Unique Identifier. */
-@JsonDeserialize
-@JsonSerialize
 public class JsonEUID {
     /** euid (__entity is used as escape sequence in JSON). */
     @JsonProperty("type")

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/SchemaSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/SchemaSerializer.java
@@ -16,26 +16,27 @@
 
 package com.cedarpolicy.serializer;
 
-import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.model.schema.Schema;
+import com.cedarpolicy.model.schema.Schema.JsonOrHuman;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 
-/** Serialize a slice. Only used internally by CedarJson */
-public class SliceSerializer extends JsonSerializer<Slice> {
+/** Serialize a schema. */
+public class SchemaSerializer extends JsonSerializer<Schema> {
 
-    /** Serialize a slice. */
+    /** Serialize a schema. */
     @Override
     public void serialize(
-            Slice slice, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            Schema schema, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
             throws IOException {
         jsonGenerator.writeStartObject();
-        jsonGenerator.writeObjectField("policies", slice.getPolicies());
-        jsonGenerator.writeObjectField("entities", slice.getEntities());
-        jsonGenerator.writeObjectField("templates", slice.getTemplates());
-        jsonGenerator.writeObjectField(
-                "templateInstantiations", slice.getTemplateLinks());
+        if (schema.type == JsonOrHuman.Json) {
+            jsonGenerator.writeObjectField("json", schema.schemaJson.get());
+        } else {
+            jsonGenerator.writeStringField("human", schema.schemaText.get());
+        }
         jsonGenerator.writeEndObject();
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
@@ -166,7 +166,7 @@ public class JSONTests {
         ObjectNode inner = JsonNodeFactory.instance.objectNode();
         inner.put("id", "jakob");
         inner.put("type", "silver");
-        n.put(ENTITY_ESCAPE_SEQ, inner);
+        n.replace(ENTITY_ESCAPE_SEQ, inner);
         assertJSONEqual(n, uid);
 
         String invalidNamespace = "Us,er::\"alice\"";
@@ -181,7 +181,7 @@ public class JSONTests {
         inner = JsonNodeFactory.instance.objectNode();
         inner.put("id", "ali\"ce");
         inner.put("type", "User");
-        n.put(ENTITY_ESCAPE_SEQ, inner);
+        n.replace(ENTITY_ESCAPE_SEQ, inner);
         assertJSONEqual(n, uid);
 
         String weirdType = "a";
@@ -191,7 +191,7 @@ public class JSONTests {
         inner = JsonNodeFactory.instance.objectNode();
         inner.put("id", weirdId);
         inner.put("type", weirdType);
-        n.put(ENTITY_ESCAPE_SEQ, inner);
+        n.replace(ENTITY_ESCAPE_SEQ, inner);
         assertJSONEqual(n, uid);
     }
 
@@ -200,7 +200,7 @@ public class JSONTests {
         var inner = JsonNodeFactory.instance.objectNode();
         inner.put("id", id);
         inner.put("type", type);
-        n.put(ENTITY_ESCAPE_SEQ, inner);
+        n.replace(ENTITY_ESCAPE_SEQ, inner);
         return n;
     }
 
@@ -213,7 +213,7 @@ public class JSONTests {
         ObjectNode inner = JsonNodeFactory.instance.objectNode();
         inner.put("id", "donut");
         inner.put("type", "long::john::silver");
-        n.put(ENTITY_ESCAPE_SEQ, inner);
+        n.replace(ENTITY_ESCAPE_SEQ, inner);
         assertJSONEqual(n, uid);
     }
 

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -38,7 +38,6 @@ import com.cedarpolicy.value.EntityUID;
 import com.cedarpolicy.serializer.JsonEUID;
 import com.cedarpolicy.value.Value;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.FileInputStream;
@@ -91,7 +90,6 @@ public class SharedIntegrationTests {
      * populated by Jackson when the test files are deserialized.
      */
     @SuppressWarnings("visibilitymodifier")
-    @JsonDeserialize
     private static class JsonTest {
         /**
          * File name of the file containing policies. Path is relative to the integration tests
@@ -123,7 +121,6 @@ public class SharedIntegrationTests {
 
     /** Directly corresponds to the structure of a request in the JSON formatted tests files. */
     @SuppressWarnings("visibilitymodifier")
-    @JsonDeserialize
     private static class JsonRequest {
         /** Textual description of the request. */
         public String description;
@@ -159,7 +156,6 @@ public class SharedIntegrationTests {
      * String, rather than String to Values.
      */
     @SuppressWarnings("visibilitymodifier")
-    @JsonDeserialize
     private static class JsonEntity {
         /** Entity uid for the entity. */
         @SuppressFBWarnings(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

More edits on my quest to match [cedar#1014](https://github.com/cedar-policy/cedar/pull/1014). Like #169, these are just refactoring to make the future PR smaller.
* Switched to using custom serializers for `Entity` and `Schema`
* Added some methods on `Policy` and `PolicySet`
* Removed some `@JsonSerialize`/`@JsonDeserialize`/`@JsonProperty` annotations that had no effect (aside from confusing me)
* Changed `put` to `replace` in some tests to get rid of a warning about deprecated functionality