### PR TITLE
Adding Policy toJson method

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -79,7 +79,7 @@ public class Policy {
         return "// Policy ID: " + policyID + "\n" + policySrc;
     }
 
-    public String toJson() {
+    public String toJson() throws InternalException, NullPointerException {
         return toJsonJni(policySrc);
     }
 
@@ -115,5 +115,5 @@ public class Policy {
     private static native boolean validateTemplateLinkedPolicyJni(String templateText, EntityUID principal, EntityUID resource)
             throws InternalException, NullPointerException;
 
-    private native String toJsonJni(String policyStr) throws NullPointerException;
+    private native String toJsonJni(String policyStr) throws InternalException, NullPointerException;
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -65,6 +65,10 @@ public class Policy {
         return "// Policy ID: " + policyID + "\n" + policySrc;
     }
 
+    public String toJson() {
+        return toJsonJni(policySrc);
+    }
+
     public static Policy parseStaticPolicy(String policyStr) throws InternalException, NullPointerException {
         var policyText = parsePolicyJni(policyStr);
         return new Policy(policyText, null);
@@ -96,4 +100,6 @@ public class Policy {
             throws InternalException, NullPointerException;
     private static native boolean validateTemplateLinkedPolicyJni(String templateText, EntityUID principal, EntityUID resource)
             throws InternalException, NullPointerException;
+
+    private native String toJsonJni(String policyStr) throws NullPointerException;
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -125,7 +125,7 @@ public class PolicyTests {
         try {
             String tbody = "permit(principal == ?principal, action, resource in ?resource);";
             Policy template = Policy.parsePolicyTemplate(tbody);
-            String actualJson = template.toJson();
+            template.toJson();
             fail("Expected InternalException");
         } catch (InternalException e) {
             assertTrue(e.getMessage().contains("expected a static policy, got a template containing the slot ?resource"));

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class PolicyTests {
     @Test
@@ -99,5 +100,35 @@ public class PolicyTests {
         assertThrows(InternalException.class, () -> {
             Policy.validateTemplateLinkedPolicy(p3, principal, resource);
         });
+    }
+
+    @Test
+    public void staticPolicyToJsonTests() throws InternalException {
+        assertThrows(NullPointerException.class, () -> {
+            Policy p = new Policy(null, null);
+            p.toJson();
+        });
+        assertThrows(InternalException.class, () -> {
+            Policy p = new Policy("permit();", null);
+            p.toJson();
+        });
+
+        Policy p = Policy.parseStaticPolicy("permit(principal, action, resource);");
+        String actualJson = p.toJson();
+        String expectedJson = "{\"effect\":\"permit\",\"principal\":{\"op\":\"All\"},\"action\":{\"op\":\"All\"},"
+                + "\"resource\":{\"op\":\"All\"},\"conditions\":[]}";
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void policyTemplateToJsonFailureTests() throws InternalException {
+        try {
+            String tbody = "permit(principal == ?principal, action, resource in ?resource);";
+            Policy template = Policy.parsePolicyTemplate(tbody);
+            String actualJson = template.toJson();
+            fail("Expected InternalException");
+        } catch (InternalException e) {
+            assertTrue(e.getMessage().contains("expected a static policy, got a template containing the slot ?resource"));
+        }
     }
 }

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -380,7 +380,7 @@ fn validate_template_linked_policy_internal<'a>(
     }
 }
 
-#[jni_fn("com.cedarpolicy.model.slice.Policy")]
+#[jni_fn("com.cedarpolicy.model.policy.Policy")]
 pub fn toJsonJni<'a>(mut env: JNIEnv<'a>, _: JClass, policy_jstr: JString<'a>) -> jvalue {
     match to_json_internal(&mut env, policy_jstr) {
         Err(e) => jni_failed(&mut env, e.as_ref()),

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -380,6 +380,26 @@ fn validate_template_linked_policy_internal<'a>(
     }
 }
 
+#[jni_fn("com.cedarpolicy.model.slice.Policy")]
+pub fn toJsonJni<'a>(mut env: JNIEnv<'a>, _: JClass, policy_jstr: JString<'a>) -> jvalue {
+    match to_json_internal(&mut env, policy_jstr) {
+        Err(e) => jni_failed(&mut env, e.as_ref()),
+        Ok(policy_json) => policy_json.as_jni(),
+    }
+}
+
+fn to_json_internal<'a>(env: &mut JNIEnv<'a>, policy_jstr: JString<'a>) -> Result<JValueOwned<'a>> {
+    if policy_jstr.is_null() {
+        raise_npe(env)
+    } else {
+        let policy_jstring = env.get_string(&policy_jstr)?;
+        let policy_string = String::from(policy_jstring);
+        let policy = Policy::from_str(&policy_string)?;
+        let policy_json = serde_json::to_string(&policy.to_json().unwrap())?;
+        Ok(JValueGen::Object(env.new_string(&policy_json)?.into()))
+    }
+}
+
 #[jni_fn("com.cedarpolicy.value.EntityIdentifier")]
 pub fn getEntityIdentifierRepr<'a>(mut env: JNIEnv<'a>, _: JClass, obj: JObject<'a>) -> jvalue {
     match get_entity_identifier_repr_internal(&mut env, obj) {


### PR DESCRIPTION
https://github.com/cedar-policy/cedar-java/issues/171

## Policy.java
* Adding `toJson` method that calls a new JNI method `toJsonJni` to return the JSON String for the Policy.

## interface.rs
* Added JNI method `toJsonJni` that takes policy source, constructs a rust Policy struct and returns the Json representation.