### PR TITLE
chore: update copyright headers

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/CedarJson.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/CedarJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/Experimental.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/Experimental.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 import java.lang.annotation.*;

--- a/CedarJava/src/main/java/com/cedarpolicy/ExperimentalFeature.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/ExperimentalFeature.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 public enum ExperimentalFeature {

--- a/CedarJava/src/main/java/com/cedarpolicy/loader/LibraryLoader.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/loader/LibraryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationSuccessResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationSuccessResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/DetailedError.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/DetailedError.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy.model;
 
 import com.cedarpolicy.Experimental;

--- a/CedarJava/src/main/java/com/cedarpolicy/model/SourceLocation.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/SourceLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/ValidationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/ValidationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/ValidationResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/ValidationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/entity/Entity.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/entity/Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/entity/package-info.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/entity/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/AuthException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/AuthException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/BadRequestException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/BadRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/DeserializationRecursionDepthException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/DeserializationRecursionDepthException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/InternalException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/InternalException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/InvalidEUIDException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/InvalidEUIDException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy.model.exception;
 
 /**

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/InvalidEscapeSequenceException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/InvalidEscapeSequenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/InvalidValueDeserializationException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/InvalidValueDeserializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/InvalidValueSerializationException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/InvalidValueSerializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/MissingExperimentalFeatureException.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/MissingExperimentalFeatureException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy.model.exception;
 
 import com.cedarpolicy.ExperimentalFeature;

--- a/CedarJava/src/main/java/com/cedarpolicy/model/exception/package-info.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/exception/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/package-info.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/LinkValue.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/LinkValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/TemplateLink.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/TemplateLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/package-info.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/model/schema/package-info.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/schema/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/package-info.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/EntitySerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/EntitySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/JsonEUID.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/JsonEUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/PolicySetSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/PolicySetSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/SchemaSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/SchemaSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/TemplateLinkSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/TemplateLinkSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/ValueDeserializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/ValueDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/ValueSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/ValueSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/package-info.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/CedarList.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/CedarList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/Decimal.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/Decimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityIdentifier.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityIdentifier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy.value;
 
 

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityTypeName.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityTypeName.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.cedarpolicy.value;
 

--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityUID.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/IpAddress.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/IpAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/PrimBool.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/PrimBool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/PrimLong.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/PrimLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/PrimString.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/PrimString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/Value.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/main/java/com/cedarpolicy/value/package-info.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/AuthTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/AuthTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 import java.util.HashMap;

--- a/CedarJava/src/test/java/com/cedarpolicy/EntityIdTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntityIdTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/CedarJava/src/test/java/com/cedarpolicy/EntityTypeNameTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntityTypeNameTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/CedarJava/src/test/java/com/cedarpolicy/EntityUIDTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntityUIDTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 import com.cedarpolicy.model.exception.InternalException;

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 import com.cedarpolicy.model.exception.InternalException;

--- a/CedarJava/src/test/java/com/cedarpolicy/SchemaTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SchemaTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cedarpolicy;
 
 import com.cedarpolicy.model.schema.Schema;

--- a/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SharedIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/TestUtil.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/ValidationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/ValidationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/package-info.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/pbt/EntityGen.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/pbt/EntityGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/pbt/IntegrationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/pbt/IntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/pbt/ParserTest.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/pbt/ParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/pbt/Utils.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/pbt/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJava/src/test/java/com/cedarpolicy/pbt/package-info.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/pbt/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJavaFFI/src/answer.rs
+++ b/CedarJavaFFI/src/answer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJavaFFI/src/jlist.rs
+++ b/CedarJavaFFI/src/jlist.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use std::marker::PhantomData;
 
 use crate::{

--- a/CedarJavaFFI/src/jset.rs
+++ b/CedarJavaFFI/src/jset.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use std::marker::PhantomData;
 
 use crate::{objects::Object, utils::Result};

--- a/CedarJavaFFI/src/lib.rs
+++ b/CedarJavaFFI/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Cedar Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CedarJavaFFI/src/objects.rs
+++ b/CedarJavaFFI/src/objects.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use crate::{
     jlist::{jstr_list_to_rust_vec, List},
     utils::{assert_is_class, get_object_ref, Result},

--- a/CedarJavaFFI/src/tests.rs
+++ b/CedarJavaFFI/src/tests.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #![cfg(test)]
 
 use crate::answer::Answer;

--- a/CedarJavaFFI/src/utils.rs
+++ b/CedarJavaFFI/src/utils.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use jni::{
     objects::{JClass, JObject, JValueGen, JValueOwned},
     JNIEnv,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Updates copyright headers to match the `cedar` and `cedar-spec` repositories (e.g., see [cedar#790](https://github.com/cedar-policy/cedar/pull/790))
* Adds the header to some files we missed.
