### PR TITLE
update policy serialization

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/ValidationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/ValidationRequest.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 /** Information passed to Cedar for validation. */
 public final class ValidationRequest {
     private final Schema schema;
-    @JsonProperty("policies")
     private final PolicySet policies;
 
     /**
@@ -64,7 +63,7 @@ public final class ValidationRequest {
      *
      * @return A `PolicySet` object
      */
-    @SuppressFBWarnings
+    @JsonProperty("policies")
     public PolicySet getPolicySet() {
         return this.policies;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

[cedar#1041](https://github.com/cedar-policy/cedar/pull/1041) uncovered a bug in #173 😱 `ValidationRequest` objects were being serialized as `{ "schema":..., "policies": ..., "policySet": ...}` where the `policies` and `policySet` values were identical. This PR gets rid of the unwanted `policySet` field.
