### PR TITLE
fix for cedar#1095

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -78,6 +78,9 @@ public class Policy {
         return "// Policy ID: " + policyID + "\n" + policySrc;
     }
 
+    /**
+     * Get the JSON representation of the policy. Currently only supports static policies.
+     */
     public String toJson() throws InternalException, NullPointerException {
         return toJsonJni(policySrc);
     }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -45,13 +45,19 @@ public class PolicyTests {
 
     @Test
     public void parsePolicyTemplateTests() {
+        // valid template
         assertDoesNotThrow(() -> {
             String tbody = "permit(principal == ?principal, action, resource in ?resource);";
             var template = Policy.parsePolicyTemplate(tbody);
             assertEquals(tbody, template.policySrc);
         });
+        // ?resource slot shouldn't be used in the principal scope
         assertThrows(InternalException.class, () -> {
             Policy.parsePolicyTemplate("permit(principal in ?resource, action, resource);");
+        });
+        // a static policy is not a template
+        assertThrows(InternalException.class, () -> {
+            Policy.parsePolicyTemplate("permit(principal, action, resource);");
         });
     }
 
@@ -75,6 +81,7 @@ public class PolicyTests {
 
     @Test
     public void policyTemplateToJsonFailureTests() throws InternalException {
+        // conversion to JSON currently only works for static policies
         try {
             String tbody = "permit(principal == ?principal, action, resource in ?resource);";
             Policy template = Policy.parsePolicyTemplate(tbody);

--- a/CedarJava/src/test/java/com/cedarpolicy/ValidationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/ValidationTests.java
@@ -105,7 +105,6 @@ public class ValidationTests {
         templates.add(new Policy("permit(principal == ?principal, action, resource in ?resource);", "template0"));
         templates.add(new Policy("permit(principal, action, resource in ?resource);", "template1"));
         templates.add(new Policy("permit(principal == ?principal, action, resource);", "template2"));
-        templates.add(new Policy("permit(principal, action, resource);", "template3"));
 
         List<TemplateLink> templateLinks = new ArrayList<>();
         LinkValue principalLink = new LinkValue("?principal", EntityUID.parse("Library::User::\"Victor\"").get());
@@ -116,7 +115,6 @@ public class ValidationTests {
         templateLinks.add(new TemplateLink("template0", "policy0", List.of(principalLink, resourceLink1)));
         templateLinks.add(new TemplateLink("template1", "policy1", List.of(resourceLink2)));
         templateLinks.add(new TemplateLink("template2", "policy2", List.of(principalLink)));
-        templateLinks.add(new TemplateLink("template3", "policy3", List.of()));
 
         this.policies = new PolicySet(new HashSet<>(), templates, templateLinks);
         ValidationResponse response = whenValidated();
@@ -131,16 +129,9 @@ public class ValidationTests {
         templates.add(new Policy("permit(principal == ?principal, action, resource in ?resource);", "template0"));
         templates.add(new Policy("permit(principal, action, resource in ?resource);", "template1"));
         templates.add(new Policy("permit(principal == ?principal, action, resource);", "template2"));
-        templates.add(new Policy("permit(principal, action, resource);", "template3"));
 
         LinkValue principalLink = new LinkValue("?principal", EntityUID.parse("Library::User::\"Victor\"").get());
         LinkValue resourceLink = new LinkValue("?resource", EntityUID.parse("Library::Book::\"The black Swan\"").get());
-
-        // fails if we try to link a template with no slots
-        this.policies = new PolicySet(new HashSet<>(), templates,
-                List.of(new TemplateLink("template3", "policy", List.of(principalLink))));
-        ValidationResponse response1 = whenValidated();
-        thenValidationFailed(response1);
 
         // fails if we provide a value for the wrong slot
         this.policies = new PolicySet(new HashSet<>(), templates,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix tests for https://github.com/cedar-policy/cedar/pull/1108, which forces `Template` objects to be templates rather than static policies.

