### PR TITLE
Add support for cedar-entity-validation

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/AuthorizationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,18 @@ public interface AuthorizationEngine {
      * @throws AuthException if any internal errors occurred while validating the policies.
      */
     ValidationResponse validate(ValidationRequest request) throws AuthException;
+
+    /**
+     * Asks whether the entities in the given {@link EntityValidationRequest} <code>q</code> are correct
+     * when validated against the schema it describes.
+     *
+     * @param request The request containing the entities to validate and the schema to validate them
+     *                against.
+     * @return A {@link ValidationResponse} describing any validation error found in the entities.
+     * @throws BadRequestException if any errors were found in the syntax of the entities.
+     * @throws AuthException if any internal errors occurred while validating the policies.
+     */
+    EntityValidationResponse validateEntities(EntityValidationRequest request) throws AuthException;
 
     /**
      * Get the Cedar language major version (e.g., "1.2") used by this CedarJava library.

--- a/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/BasicAuthorizationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,12 @@ public final class BasicAuthorizationEngine implements AuthorizationEngine {
     public ValidationResponse validate(ValidationRequest q) throws AuthException {
         LOG.trace("Making a validate request:\n{}", q);
         return call("ValidateOperation", ValidationResponse.class, q);
+    }
+
+    @Override
+    public EntityValidationResponse validateEntities(EntityValidationRequest q) throws AuthException {
+        LOG.trace("Making an entities validate request:\n{}", q);
+        return call("ValidateEntities", EntityValidationResponse.class, q);
     }
 
     private static <REQ, RESP> RESP call(String operation, Class<RESP> responseClass, REQ request)

--- a/CedarJava/src/main/java/com/cedarpolicy/CedarJson.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/CedarJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package com.cedarpolicy;
 
+import com.cedarpolicy.model.slice.Entity;
 import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.serializer.EntitySerializer;
 import com.cedarpolicy.serializer.ValueCedarDeserializer;
 import com.cedarpolicy.serializer.ValueCedarSerializer;
 import com.cedarpolicy.value.Value;
@@ -50,6 +52,7 @@ final class CedarJson {
 
         final SimpleModule module = new SimpleModule();
         module.addSerializer(Slice.class, new SliceJsonSerializer());
+        module.addSerializer(Entity.class, new EntitySerializer());
         module.addSerializer(Value.class, new ValueCedarSerializer());
         module.addDeserializer(Value.class, new ValueCedarDeserializer());
         mapper.registerModule(module);

--- a/CedarJava/src/main/java/com/cedarpolicy/model/EntityValidationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/EntityValidationRequest.java
@@ -1,0 +1,81 @@
+ /*
+  * Copyright 2022-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      https://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+ package com.cedarpolicy.model;
+
+ import java.util.List;
+ import java.util.Objects;
+
+ import com.cedarpolicy.model.schema.Schema;
+ import com.cedarpolicy.model.slice.Entity;
+ import com.fasterxml.jackson.annotation.JsonProperty;
+
+ /**
+  * Information passed to Cedar for entities validation.
+  */
+ public final class EntityValidationRequest {
+     @JsonProperty("schema")
+     private final Schema schema;
+     @JsonProperty("entities")
+     private final List<Entity> entities;
+
+     /**
+      * Construct a validation request.
+      *
+      * @param schema   Schema for the request
+      * @param entities Map.
+      */
+     public EntityValidationRequest(Schema schema, List<Entity> entities) {
+         if (schema == null) {
+             throw new NullPointerException("schema");
+         }
+
+         if (entities == null) {
+             throw new NullPointerException("entities");
+         }
+
+         this.schema = schema;
+         this.entities = entities;
+     }
+
+     /**
+      * Test equality.
+      */
+     @Override
+     public boolean equals(final Object o) {
+         if (!(o instanceof EntityValidationRequest)) {
+             return false;
+         }
+
+         final EntityValidationRequest other = (EntityValidationRequest) o;
+         return schema.equals(other.schema) && entities.equals(other.entities);
+     }
+
+     /**
+      * Hash.
+      */
+     @Override
+     public int hashCode() {
+         return Objects.hash(schema, entities);
+     }
+
+     /**
+      * Get readable string representation.
+      */
+     public String toString() {
+         return "EntityValidationRequest(schema=" + schema + ", entities=" + entities + ")";
+     }
+ }

--- a/CedarJava/src/main/java/com/cedarpolicy/model/EntityValidationResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/EntityValidationResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cedarpolicy.model;
+
+
+/**
+ * Result of a entity validation request.
+ */
+public final class EntityValidationResponse {
+    private final String message;
+
+    EntityValidationResponse(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Get message.
+     *
+     * @return message.
+     */
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/EntitySerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/EntitySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,30 +14,29 @@
  * limitations under the License.
  */
 
-package com.cedarpolicy;
+package com.cedarpolicy.serializer;
 
-import com.cedarpolicy.model.slice.Slice;
+import com.cedarpolicy.model.slice.Entity;
+import com.cedarpolicy.value.EntityUID;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
+import java.util.stream.Collectors;
 
+/** Serialize an entity. */
+public class EntitySerializer extends JsonSerializer<Entity> {
 
-/** Serialize a slice. Only used internally by CedarJson */
-class SliceJsonSerializer extends JsonSerializer<Slice> {
-
-    /** Serialize a slice. */
+    /** Serialize an entity. */
     @Override
     public void serialize(
-            Slice slice, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            Entity entity, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
             throws IOException {
         jsonGenerator.writeStartObject();
-        jsonGenerator.writeObjectField("policies", slice.getPolicies());
-        jsonGenerator.writeObjectField(
-                "entities", slice.getEntities());
-        jsonGenerator.writeObjectField("templates", slice.getTemplates());
-        jsonGenerator.writeObjectField(
-                "template_instantiations", slice.getTemplateInstantiations());
+        jsonGenerator.writeObjectField("uid", entity.getEUID().asJson());
+        jsonGenerator.writeObjectField("attrs", entity.attrs);
+        jsonGenerator.writeObjectField("parents",
+                entity.getParents().stream().map(EntityUID::asJson).collect(Collectors.toSet()));
         jsonGenerator.writeEndObject();
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/EntityValidationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntityValidationTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cedarpolicy;
+
+import static com.cedarpolicy.TestUtil.loadSchemaResource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+
+import com.cedarpolicy.model.EntityValidationRequest;
+import com.cedarpolicy.model.EntityValidationResponse;
+
+import com.cedarpolicy.model.exception.AuthException;
+import com.cedarpolicy.model.schema.Schema;
+import com.cedarpolicy.model.slice.Entity;
+import com.cedarpolicy.pbt.EntityGen;
+import com.cedarpolicy.value.EntityTypeName;
+import com.cedarpolicy.value.PrimBool;
+
+
+/**
+ * Tests for entity validator
+ */
+public class EntityValidationTests {
+    private static EntityGen entityGen;
+    private static AuthorizationEngine engine;
+
+    /**
+     * Test that a valid entity is accepted.
+     */
+    @Test
+    public void testValidEntity() throws AuthException {
+        Entity entity = EntityValidationTests.entityGen.arbitraryEntity();
+
+        EntityValidationRequest r = new EntityValidationRequest(
+                ROLE_SCHEMA, List.of(entity));
+
+        EntityValidationResponse result = engine.validateEntities(r);
+
+        assertEquals(result.getMessage(), "Entities parsed correctly");
+    }
+
+    /**
+     * Test that an entity with an attribute not specified in the schema throws an exception.
+     */
+    @Test
+    public void testEntityWithUnknownAttribute() throws AuthException {
+        Entity entity = EntityValidationTests.entityGen.arbitraryEntity();
+        entity.attrs.put("test", new PrimBool(true));
+
+        EntityValidationRequest request = new EntityValidationRequest(
+                ROLE_SCHEMA, List.of(entity));
+
+
+        AuthException exception = assertThrows(AuthException.class, () -> engine.validateEntities(request));
+        assertTrue(
+                exception.message.orElse("")
+                        .startsWith("Bad request: error during entity deserialization: attribute `test` on "),
+                "Expected exception message to start with 'Bad request: error during entity deserialization: attribute `test` on'");
+    }
+
+    /**
+     * Test that entities with a cyclic parent relationship throw an exception.
+     */
+    @Test
+    public void testEntitiesWithCyclicParentRelationship() throws AuthException {
+        // Arrange
+        Entity childEntity = EntityValidationTests.entityGen.arbitraryEntity();
+        Entity parentEntity = EntityValidationTests.entityGen.arbitraryEntity();
+
+        // Create a cyclic parent relationship between the entities
+        childEntity.parentsEUIDs.add(parentEntity.getEUID());
+        parentEntity.parentsEUIDs.add(childEntity.getEUID());
+
+        EntityValidationRequest request = new EntityValidationRequest(
+                ROLE_SCHEMA,
+                List.of(parentEntity, childEntity));
+
+        // Act & Assert
+        AuthException exception = assertThrows(AuthException.class, () -> engine.validateEntities(request));
+        assertTrue(
+                exception.message.orElse("")
+                        .startsWith("Bad request: transitive closure computation/enforcement error:"),
+                "Expected exception message to start with 'Bad request: transitive closure computation/enforcement error:'");
+    }
+    
+    @BeforeAll
+    public static void setUp() {
+
+        engine = new BasicAuthorizationEngine();
+        EntityTypeName user = EntityTypeName.parse("Role").get();
+
+        EntityValidationTests.entityGen = new EntityGen(user);
+    }
+
+    private static final Schema ROLE_SCHEMA = loadSchemaResource("/role_schema.json");
+}

--- a/CedarJava/src/test/resources/role_schema.json
+++ b/CedarJava/src/test/resources/role_schema.json
@@ -1,0 +1,12 @@
+{
+  "": {
+    "entityTypes": {
+      "Role": {
+        "memberOfTypes": [
+          "Role"
+        ]
+      }
+    },
+    "actions": {}
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


This PR adds support for cedar-entity-validation.

- Refactor Entity json serialization similar to release/4.0.x
- Add entity validation in rust 
- Add entity validation in java 
- Add unit test in java and rust.