### PR TITLE
improve a few error messages in tests

### DIFF
--- a/CedarJavaFFI/src/tests.rs
+++ b/CedarJavaFFI/src/tests.rs
@@ -541,7 +541,9 @@ mod entity_validation_tests {
         assert_failure(&result);
 
         assert!(
-            result.contains("unknown field `shape44`, expected one of `memberOfTypes`, `shape`, `tags`"),
+            result.contains(
+                "unknown field `shape44`, expected one of `memberOfTypes`, `shape`, `tags`"
+            ),
             "result was `{result}`",
         );
     }

--- a/CedarJavaFFI/src/tests.rs
+++ b/CedarJavaFFI/src/tests.rs
@@ -29,6 +29,7 @@ fn assert_failure(result: &str) {
     assert_matches!(result, Answer::Failure { .. });
 }
 
+#[track_caller]
 fn assert_success(result: &str) {
     let result: Answer = serde_json::from_str(result).unwrap();
     assert_matches!(result, Answer::Success { .. });

--- a/CedarJavaFFI/src/tests.rs
+++ b/CedarJavaFFI/src/tests.rs
@@ -31,10 +31,7 @@ fn assert_failure(result: &str) {
 
 fn assert_success(result: &str) {
     let result: Answer = serde_json::from_str(result).unwrap();
-    match result {
-        Answer::Success { .. } => {}
-        Answer::Failure { .. } => panic!("expected a success, not {:?}", result),
-    };
+    assert_matches!(result, Answer::Success { .. });
 }
 
 #[track_caller]

--- a/CedarJavaFFI/src/tests.rs
+++ b/CedarJavaFFI/src/tests.rs
@@ -24,8 +24,8 @@ use cedar_policy::ffi::{AuthorizationAnswer, ValidationAnswer};
 use cool_asserts::assert_matches;
 
 #[track_caller]
-fn assert_failure(result: String) {
-    let result: Answer = serde_json::from_str(result.as_str()).unwrap();
+fn assert_failure(result: &str) {
+    let result: Answer = serde_json::from_str(result).unwrap();
     assert_matches!(result, Answer::Failure { .. });
 }
 
@@ -65,7 +65,7 @@ fn assert_validation_success(result: String) {
 #[test]
 fn unrecognized_call_fails() {
     let result = call_cedar("BadOperation", "");
-    assert_failure(result);
+    assert_failure(&result);
 }
 
 mod authorization_tests {
@@ -503,13 +503,13 @@ mod entity_validation_tests {
             }
         });
         let result = call_cedar("ValidateEntities", json_data.to_string().as_str());
-        assert_failure(result);
+        assert_failure(&result);
     }
 
     #[test]
     #[should_panic]
     fn validate_entities_invalid_json_fails() {
-        let result = call_cedar("ValidateEntities", "{]");
+        call_cedar("ValidateEntities", "{]");
     }
 
     #[test]
@@ -538,10 +538,12 @@ mod entity_validation_tests {
             }
         });
         let result = call_cedar("ValidateEntities", json_data.to_string().as_str());
-        assert_failure(result.clone());
+        assert_failure(&result);
 
-        assert!(result
-            .contains("unknown field `shape44`, expected one of `memberOfTypes`, `shape`, `tags`"));
+        assert!(
+            result.contains("unknown field `shape44`, expected one of `memberOfTypes`, `shape`, `tags`"),
+            "result was `{result}`",
+        );
     }
 
     #[test]
@@ -595,9 +597,12 @@ mod entity_validation_tests {
             }
         });
         let result = call_cedar("ValidateEntities", json_data.to_string().as_str());
-        assert_failure(result.clone());
+        assert_failure(&result);
 
-        assert!(result.contains("input graph has a cycle containing vertex `PhotoApp::UserGroup"));
+        assert!(
+            result.contains("input graph has a cycle containing vertex `PhotoApp::UserGroup"),
+            "result was `{result}`",
+        );
     }
 }
 

--- a/CedarJavaFFI/src/tests.rs
+++ b/CedarJavaFFI/src/tests.rs
@@ -29,8 +29,8 @@ fn assert_failure(result: &str) {
     assert_matches!(result, Answer::Failure { .. });
 }
 
-fn assert_success(result: String) {
-    let result: Answer = serde_json::from_str(result.as_str()).unwrap();
+fn assert_success(result: &str) {
+    let result: Answer = serde_json::from_str(result).unwrap();
     match result {
         Answer::Success { .. } => {}
         Answer::Failure { .. } => panic!("expected a success, not {:?}", result),
@@ -353,7 +353,7 @@ mod entity_validation_tests {
             }
         });
         let result = call_cedar("ValidateEntities", json_data.to_string().as_str());
-        assert_success(result);
+        assert_success(&result);
     }
 
     #[test]

--- a/CedarJavaFFI/src/tests.rs
+++ b/CedarJavaFFI/src/tests.rs
@@ -36,27 +36,27 @@ fn assert_success(result: &str) {
 }
 
 #[track_caller]
-fn assert_authorization_success(result: String) {
-    let result: AuthorizationAnswer = serde_json::from_str(result.as_str()).unwrap();
+fn assert_authorization_success(result: &str) {
+    let result: AuthorizationAnswer = serde_json::from_str(result).unwrap();
     assert_matches!(result, AuthorizationAnswer::Success { .. });
 }
 
 #[track_caller]
-fn assert_authorization_failure(result: String) {
-    let result: AuthorizationAnswer = serde_json::from_str(result.as_str()).unwrap();
+fn assert_authorization_failure(result: &str) {
+    let result: AuthorizationAnswer = serde_json::from_str(result).unwrap();
     assert_matches!(result, AuthorizationAnswer::Failure { .. });
 }
 
 #[cfg(feature = "partial-eval")]
 #[track_caller]
-fn assert_partial_authorization_success(result: String) {
-    let result: PartialAuthorizationAnswer = serde_json::from_str(result.as_str()).unwrap();
+fn assert_partial_authorization_success(result: &str) {
+    let result: PartialAuthorizationAnswer = serde_json::from_str(result).unwrap();
     assert_matches!(result, PartialAuthorizationAnswer::Residuals { .. });
 }
 
 #[track_caller]
-fn assert_validation_success(result: String) {
-    let result: ValidationAnswer = serde_json::from_str(result.as_str()).unwrap();
+fn assert_validation_success(result: &str) {
+    let result: ValidationAnswer = serde_json::from_str(result).unwrap();
     assert_matches!(result, ValidationAnswer::Success { .. });
 }
 
@@ -84,7 +84,7 @@ mod authorization_tests {
     }
             "#,
         );
-        assert_authorization_success(result);
+        assert_authorization_success(&result);
     }
 
     #[test]
@@ -108,7 +108,7 @@ mod authorization_tests {
     }
     "#,
         );
-        assert_authorization_failure(result);
+        assert_authorization_failure(&result);
     }
 
     #[test]
@@ -132,7 +132,7 @@ mod authorization_tests {
     }
     "#,
         );
-        assert_authorization_failure(result);
+        assert_authorization_failure(&result);
     }
 
     #[test]
@@ -176,7 +176,7 @@ mod authorization_tests {
         }
             "#,
         );
-        assert_authorization_success(result);
+        assert_authorization_success(&result);
     }
 }
 
@@ -186,13 +186,13 @@ mod validation_tests {
     #[test]
     fn empty_validation_call_json_schema_succeeds() {
         let result = call_cedar("ValidateOperation", r#"{ "schema": {}, "policies": {} }"#);
-        assert_validation_success(result);
+        assert_validation_success(&result);
     }
 
     #[test]
     fn empty_validation_call_succeeds() {
         let result = call_cedar("ValidateOperation", r#"{ "schema": "", "policies": {} }"#);
-        assert_validation_success(result);
+        assert_validation_success(&result);
     }
 }
 
@@ -630,7 +630,7 @@ mod partial_authorization_tests {
     }
     "#,
         );
-        assert_partial_authorization_success(result);
+        assert_partial_authorization_success(&result);
     }
 
     #[test]
@@ -653,7 +653,7 @@ mod partial_authorization_tests {
     }
     "#,
         );
-        assert_partial_authorization_success(result);
+        assert_partial_authorization_success(&result);
     }
 }
 


### PR DESCRIPTION
and also switch from owned `String` to `&str` in a function that didn't need ownership