### PR TITLE
Adding support for entity tags

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/entity/Entity.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/entity/Entity.java
@@ -25,8 +25,8 @@ import java.util.stream.Collectors;
 /**
  * An entity is the kind of object about which authorization decisions are made; principals,
  * actions, and resources are all a kind of entity. Each entity is defined by its entity type, a
- * unique identifier (UID), zero or more attributes mapped to values, and zero or more parent
- * entities.
+ * unique identifier (UID), zero or more attributes mapped to values, zero or more parent
+ * entities, and zero or more tags.
  */
 public class Entity {
     private final EntityUID euid;
@@ -37,6 +37,9 @@ public class Entity {
     /** Set of entity EUIDs that are parents to this entity. */
     public final Set<EntityUID> parentsEUIDs;
 
+    /** Tags on this entity (RFC 82) */
+    public final Map<String, Value> tags;
+
     /**
      * Create an entity from an EntityUIDs, a map of attributes, and a set of parent EntityUIDs.
      *
@@ -45,9 +48,22 @@ public class Entity {
      * @param parentsEUIDs Set of parent entities' EUIDs.
      */
     public Entity(EntityUID uid, Map<String, Value> attributes, Set<EntityUID> parentsEUIDs) {
+        this(uid, attributes, parentsEUIDs, new HashMap<>());
+    }
+
+    /**
+     * Create an entity from an EntityUIDs, a map of attributes, a set of parent EntityUIDs, and a map of tags.
+     *
+     * @param uid EUID of the Entity.
+     * @param attributes Key/Value map of attributes.
+     * @param parentsEUIDs Set of parent entities' EUIDs.
+     * @param tags Key/Value map of tags.
+     */
+    public Entity(EntityUID uid, Map<String, Value> attributes, Set<EntityUID> parentsEUIDs, Map<String, Value> tags) {
         this.attrs = new HashMap<>(attributes);
         this.euid = uid;
         this.parentsEUIDs = parentsEUIDs;
+        this.tags = new HashMap<>(tags);
     }
 
     @Override
@@ -66,7 +82,15 @@ public class Entity {
                                     .map(e -> e.getKey() + ": " + e.getValue())
                                     .collect(Collectors.joining("\n\t\t"));
         }
-        return euid.toString() + parentStr + attributeStr;
+        String tagsStr = "";
+        if (!tags.isEmpty()) {
+            tagsStr =
+                    "\n\ttags:\n\t\t"
+                            + tags.entrySet().stream()
+                                    .map(e -> e.getKey() + ": " + e.getValue())
+                                    .collect(Collectors.joining("\n\t\t"));
+        }
+        return euid.toString() + parentStr + attributeStr + tagsStr;
     }
 
 
@@ -79,10 +103,18 @@ public class Entity {
     }
 
     /**
-     * Get this Entities parents
+     * Get this Entity's parents
      * @return the set of parent EntityUIDs
      */
     public Set<EntityUID> getParents() {
         return parentsEUIDs;
+    }
+
+    /**
+     * Get this Entity's tags
+     * @return the map of tags
+     */
+    public Map<String, Value> getTags() {
+        return tags;
     }
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/EntitySerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/EntitySerializer.java
@@ -37,6 +37,7 @@ public class EntitySerializer extends JsonSerializer<Entity> {
         jsonGenerator.writeObjectField("attrs", entity.attrs);
         jsonGenerator.writeObjectField("parents",
                 entity.getParents().stream().map(EntityUID::asJson).collect(Collectors.toSet()));
+        jsonGenerator.writeObjectField("tags", entity.tags);
         jsonGenerator.writeEndObject();
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/EntityValidationTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntityValidationTests.java
@@ -35,7 +35,7 @@ import com.cedarpolicy.model.schema.Schema;
 import com.cedarpolicy.pbt.EntityGen;
 import com.cedarpolicy.value.EntityTypeName;
 import com.cedarpolicy.value.PrimBool;
-
+import com.cedarpolicy.value.PrimString;
 
 /**
  * Tests for entity validator
@@ -94,6 +94,24 @@ public class EntityValidationTests {
         String errMsg = exception.getErrors().get(0);
         assertTrue(errMsg.matches("input graph has a cycle containing vertex `Role::\".*\"`"),
                 "Expected to match regex but was: '%s'".formatted(errMsg));
+    }
+
+    /**
+     * Test that an entity with a tag not specified in the schema throws an exception.
+     */
+    @Test
+    public void testEntityWithUnknownTag() throws AuthException {
+        Entity entity = EntityValidationTests.entityGen.arbitraryEntity();
+        entity.tags.put("test", new PrimString("value"));
+
+        EntityValidationRequest request = new EntityValidationRequest(ROLE_SCHEMA, List.of(entity));
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> engine.validateEntities(request));
+
+        String errMsg = exception.getErrors().get(0);
+        assertTrue(errMsg.matches("found a tag `test` on `Role::\".*\"`, "
+            + "but no tags should exist on `Role::\".*\"` according to the schema"),
+            "Expected to match regex but was: '%s'".formatted(errMsg));
     }
 
     @BeforeAll


### PR DESCRIPTION
### Use Case
Entity tagging is new in Cedar 4.2.x, but CedarJava 4.2.x is not able to leverage it with the current Entity object and serializer.

### Details

* Adding `tags` field to `Entity.java` to support entities with tags
* Updated `EntitySerializer.java` to make sure the tags field makes it across the JNI layer and into the AuthorizationRequest string we pass.
* Quality of life improvement: returning the error message in the case of Validation errors in the corpus/json tests in `executeJsonValidationTest`

### Testing

* Added `testEntityWithUnknownTag` to  `EntityValidationTests.java`
* Created a temporary extra json test among `JSON_TEST_FILES` that tested e2e allowing an action contingent on a tag being present in the resource.