### PR TITLE
Use Rust 1.81 to crossbuild FFI

### DIFF
--- a/.github/workflows/run_cedar_java_reusable.yml
+++ b/.github/workflows/run_cedar_java_reusable.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
       - name: Prepare Rust Build
-        run: rustup install 1.81 && rustup default 1.81 && rustup component add rustfmt
+        run: rustup install stable && rustup default stable 
       - name: Configure CedarJavaFFI for CI build
         run: bash configure_ci_build.sh
       - name: Check FFI Formatting

--- a/.github/workflows/run_cedar_java_reusable.yml
+++ b/.github/workflows/run_cedar_java_reusable.yml
@@ -40,8 +40,7 @@ jobs:
           ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
       - name: Prepare Rust Build
-        # zigbuild issue: rust-cross/cargo-zigbuild#289
-        run: rustup install 1.81 && rustup default 1.81 && rustup component add rustfmt 
+        run: rustup install stable && rustup default stable
       - name: Configure CedarJavaFFI for CI build
         run: bash configure_ci_build.sh
       - name: Check FFI Formatting

--- a/.github/workflows/run_cedar_java_reusable.yml
+++ b/.github/workflows/run_cedar_java_reusable.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
       - name: Prepare Rust Build
-        run: rustup install stable && rustup default stable
+        run: rustup install 1.81 && rustup default 1.81 && rustup component add rustfmt
       - name: Configure CedarJavaFFI for CI build
         run: bash configure_ci_build.sh
       - name: Check FFI Formatting

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -125,13 +125,13 @@ tasks.register('compileFFI') {
     dependsOn('installCargoZigbuild')
     group 'Build'
     description 'Compiles Foreign Function Interface libraries.'
-    exec {
-      workingDir = ffiDir
-      commandLine 'rustup', 'override', 'set', '1.81'
-    }
 
     doLast {
         rustLibraryTargets.forEach { rustTarget, libraryFile ->
+        exec {
+            workingDir = ffiDir
+            commandLine 'rustup', 'override', 'set', '1.81'
+            }
             exec {
                 commandLine 'rustup', 'target', 'add', rustTarget
             }

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -107,34 +107,34 @@ def rustJavaTargets = [
         'x86_64-unknown-linux-gnu' : 'linux/x86_64'
 ]
 
+tasks.register('installRequiredRustVersion', Exec) {
+  group 'Build' 
+  description 'Install required Rust version.'
+  commandLine 'rustup', 'install', '1.81'
+}
+
 tasks.register('installCargoZigbuild', Exec) {
+    dependsOn('installRequiredRustVersion')
     group 'Build'
     description 'Installs Cargo Zigbuild for Rust compilation.'
 
     commandLine 'cargo', 'install', 'cargo-zigbuild@0.19.3'
 }
 
-tasks.register('installRustTargets') {
+tasks.register('compileFFI') {
     dependsOn('installCargoZigbuild')
     group 'Build'
-    description 'Installs Rust platform build targets.'
-
-    doLast {
-        rustLibraryTargets.keySet().forEach { rustTarget ->
-            exec {
-                commandLine 'rustup', 'target', 'add', rustTarget
-            }
-        }
-    }
-}
-
-tasks.register('compileFFI') {
-    dependsOn('installRustTargets')
-    group 'Build'
     description 'Compiles Foreign Function Interface libraries.'
+    exec {
+      workingDir = ffiDir
+      commandLine 'rustup', 'override', 'set', '1.81'
+    }
 
     doLast {
         rustLibraryTargets.forEach { rustTarget, libraryFile ->
+            exec {
+                commandLine 'rustup', 'target', 'add', rustTarget
+            }
             exec {
                 workingDir = ffiDir
                 commandLine 'cargo', 'zigbuild', '--features', 'partial-eval', '--release', '--target', rustTarget

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -107,10 +107,12 @@ def rustJavaTargets = [
         'x86_64-unknown-linux-gnu' : 'linux/x86_64'
 ]
 
+def RustVersion = '1.81'
+
 tasks.register('installRequiredRustVersion', Exec) {
-  group 'Build' 
+  group 'Build'
   description 'Install required Rust version.'
-  commandLine 'rustup', 'install', '1.81'
+  commandLine 'rustup', 'install', RustVersion
 }
 
 tasks.register('installCargoZigbuild', Exec) {
@@ -118,26 +120,26 @@ tasks.register('installCargoZigbuild', Exec) {
     group 'Build'
     description 'Installs Cargo Zigbuild for Rust compilation.'
 
-    commandLine 'cargo', '+1.81', 'install', 'cargo-zigbuild@0.19.3'
+    commandLine 'cargo', '+' + RustVersion, 'install', 'cargo-zigbuild@0.19.3'
 }
 
 tasks.register('compileFFI') {
     dependsOn('installCargoZigbuild')
     group 'Build'
     description 'Compiles Foreign Function Interface libraries.'
-        exec {
-            workingDir = ffiDir
-            commandLine 'rustup', 'override', 'set', '1.81'
-        }
+    exec {
+        workingDir = ffiDir
+        commandLine 'rustup', 'override', 'set', RustVersion
+    }
 
     doLast {
         rustLibraryTargets.forEach { rustTarget, libraryFile ->
             exec {
-                commandLine 'rustup', 'target', 'add', rustTarget, '--toolchain', '1.81'
+                commandLine 'rustup', 'target', 'add', rustTarget, '--toolchain', RustVersion
             }
             exec {
                 workingDir = ffiDir
-                commandLine 'cargo', '+1.81', 'zigbuild', '--features', 'partial-eval', '--release', '--target', rustTarget
+                commandLine 'cargo', '+' + RustVersion, 'zigbuild', '--features', 'partial-eval', '--release', '--target', rustTarget
             }
 
             def sourcePath = "${ffiDir}/target/${rustTarget}/release/${libraryFile}"

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -118,26 +118,26 @@ tasks.register('installCargoZigbuild', Exec) {
     group 'Build'
     description 'Installs Cargo Zigbuild for Rust compilation.'
 
-    commandLine 'cargo', 'install', 'cargo-zigbuild@0.19.3'
+    commandLine 'cargo', '+1.81', 'install', 'cargo-zigbuild@0.19.3'
 }
 
 tasks.register('compileFFI') {
     dependsOn('installCargoZigbuild')
     group 'Build'
     description 'Compiles Foreign Function Interface libraries.'
-
-    doLast {
-        rustLibraryTargets.forEach { rustTarget, libraryFile ->
         exec {
             workingDir = ffiDir
             commandLine 'rustup', 'override', 'set', '1.81'
-            }
+        }
+
+    doLast {
+        rustLibraryTargets.forEach { rustTarget, libraryFile ->
             exec {
-                commandLine 'rustup', 'target', 'add', rustTarget
+                commandLine 'rustup', 'target', 'add', rustTarget, '--toolchain', '1.81'
             }
             exec {
                 workingDir = ffiDir
-                commandLine 'cargo', 'zigbuild', '--features', 'partial-eval', '--release', '--target', rustTarget
+                commandLine 'cargo', '+1.81', 'zigbuild', '--features', 'partial-eval', '--release', '--target', rustTarget
             }
 
             def sourcePath = "${ffiDir}/target/${rustTarget}/release/${libraryFile}"

--- a/CedarJavaFFI/rust-toolchain.toml
+++ b/CedarJavaFFI/rust-toolchain.toml
@@ -1,0 +1,3 @@
+# zigbuild currently does not work on Rust 1.82 (rust-cross/cargo-zigbuild#289)
+[toolchain]
+channel = "1.81"

--- a/CedarJavaFFI/rust-toolchain.toml
+++ b/CedarJavaFFI/rust-toolchain.toml
@@ -1,3 +1,0 @@
-# zigbuild currently does not work on Rust 1.82 (rust-cross/cargo-zigbuild#289)
-[toolchain]
-channel = "1.81"


### PR DESCRIPTION
*Issue #, if available:*

#251 

*Description of changes:*

This PR enforces `build.gradle` to use Rust 1.81, which is specified by a constant.
