### PR TITLE
Add toString method to CedarMap

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
@@ -141,4 +141,9 @@ public final class CedarMap extends Value implements Map<String, Value> {
     public Collection<Value> values() {
         return map.values();
     }
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While debugging policies it is difficult to see what is included in the `CedarMap` object. Adding a `toString` in the same manner as the `CedarList` enables better debugging.

