### PR TITLE
Exposes policy effect for static policies and templates

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/Effect.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/Effect.java
@@ -1,0 +1,34 @@
+package com.cedarpolicy.model;
+
+/**
+ * Represents the effect of a Cedar policy.
+ */
+public enum Effect {
+    PERMIT,
+    FORBID;
+
+    /**
+     * Converts a string to an Effect enum value, case-insensitive.
+     *
+     * @param effectString the string value to convert
+     * @return the corresponding Effect enum value
+     * @throws NullPointerException if the effectString is null
+     * @throws IllegalArgumentException if the effectString doesn't match any Effect in {permit, forbid}
+     */
+    public static Effect fromString(String effectString) {
+
+        if (effectString == null) {
+            throw new NullPointerException();
+        }
+
+        switch (effectString.toLowerCase()) {
+            case "permit":
+                return PERMIT;
+            case "forbid":
+                return FORBID;
+            default:
+                throw new IllegalArgumentException("Invalid Effect: " + effectString + ". Expected 'permit' or 'forbid'");
+        }
+    }
+}
+

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -79,6 +79,24 @@ public class Policy {
     }
 
     /**
+     * Returns the effect of a policy. 
+     * 
+     * Determines the policy effect by attempting static policy first, then template. 
+     * In future, it will only support static policies once new class is introduced for Template.
+     * 
+     * @return The effect of the policy, either "permit" or "forbid"
+     * @throws InternalException
+     * @throws NullPointerException
+     */
+    public String effect() throws InternalException, NullPointerException {
+        try {
+            return policyEffectJni(policySrc); // Get effect for static policy
+        } catch (InternalException e) {
+            return templateEffectJni(policySrc); // Get effect for template
+        }
+    }
+
+    /**
      * Get the JSON representation of the policy. Currently only supports static policies.
      */
     public String toJson() throws InternalException, NullPointerException {
@@ -106,4 +124,6 @@ public class Policy {
 
     private native String toJsonJni(String policyStr) throws InternalException, NullPointerException;
     private static native String fromJsonJni(String policyJsonStr) throws InternalException, NullPointerException;
+    private native String policyEffectJni(String policyStr) throws InternalException, NullPointerException;
+    private native String templateEffectJni(String policyStr) throws InternalException, NullPointerException;
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -20,6 +20,7 @@ import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.model.exception.InternalException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.cedarpolicy.model.Effect;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -79,20 +80,20 @@ public class Policy {
     }
 
     /**
-     * Returns the effect of a policy. 
-     * 
-     * Determines the policy effect by attempting static policy first, then template. 
+     * Returns the effect of a policy.
+     *
+     * Determines the policy effect by attempting static policy first, then template.
      * In future, it will only support static policies once new class is introduced for Template.
-     * 
+     *
      * @return The effect of the policy, either "permit" or "forbid"
      * @throws InternalException
      * @throws NullPointerException
      */
-    public String effect() throws InternalException, NullPointerException {
+    public Effect effect() throws InternalException, NullPointerException {
         try {
-            return policyEffectJni(policySrc); // Get effect for static policy
+            return Effect.fromString(policyEffectJni(policySrc)); // Get effect for static policy
         } catch (InternalException e) {
-            return templateEffectJni(policySrc); // Get effect for template
+            return Effect.fromString(templateEffectJni(policySrc)); // Get effect for template
         }
     }
 

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -109,4 +109,36 @@ public class PolicyTests {
         String actualJson = p.toJson();
         assertEquals(validJson, actualJson);
     }
+
+    @Test void policyEffectTest() throws InternalException {
+
+        assertThrows(NullPointerException.class, () -> {
+            Policy p = new Policy(null, null);
+            p.toJson();
+        });
+
+        // For effects not in {permit, forbid}
+        assertThrows(InternalException.class, () -> {
+            Policy p = new Policy("perm(principal == ?principal, action, resource in ?resource);", null);
+            p.toJson();
+        });
+
+        String actualPermitValue = "\"permit\"";
+        String actualForbidValue = "\"forbid\"";
+
+        // Tests for static policies
+        Policy permitPolicy = new Policy("permit(principal, action, resource);", null);
+        assertEquals(permitPolicy.effect(), actualPermitValue);
+
+        Policy forbidPolicy = new Policy("forbid(principal, action, resource);", null);
+        assertEquals(forbidPolicy.effect(), actualForbidValue);
+
+        // Tests for templates
+        Policy permitTemplate = new Policy("permit(principal == ?principal, action, resource == ?resource);", null);
+        assertEquals(permitTemplate.effect(), actualPermitValue);
+
+        Policy forbidTemplate = new Policy("forbid(principal == ?principal, action, resource == ?resource);", null);
+        assertEquals(forbidTemplate.effect(), actualForbidValue);
+
+    }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -18,6 +18,7 @@ package com.cedarpolicy;
 
 import com.cedarpolicy.model.exception.InternalException;
 import com.cedarpolicy.model.policy.Policy;
+import com.cedarpolicy.model.Effect;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -114,31 +115,28 @@ public class PolicyTests {
 
         assertThrows(NullPointerException.class, () -> {
             Policy p = new Policy(null, null);
-            p.toJson();
+            p.effect();
         });
 
         // For effects not in {permit, forbid}
         assertThrows(InternalException.class, () -> {
             Policy p = new Policy("perm(principal == ?principal, action, resource in ?resource);", null);
-            p.toJson();
+            p.effect();
         });
-
-        String actualPermitValue = "permit";
-        String actualForbidValue = "forbid";
 
         // Tests for static policies
         Policy permitPolicy = new Policy("permit(principal, action, resource);", null);
-        assertEquals(permitPolicy.effect(), actualPermitValue);
+        assertEquals(permitPolicy.effect(), Effect.PERMIT);
 
         Policy forbidPolicy = new Policy("forbid(principal, action, resource);", null);
-        assertEquals(forbidPolicy.effect(), actualForbidValue);
+        assertEquals(forbidPolicy.effect(), Effect.FORBID);
 
         // Tests for templates
         Policy permitTemplate = new Policy("permit(principal == ?principal, action, resource == ?resource);", null);
-        assertEquals(permitTemplate.effect(), actualPermitValue);
+        assertEquals(permitTemplate.effect(), Effect.PERMIT);
 
         Policy forbidTemplate = new Policy("forbid(principal == ?principal, action, resource == ?resource);", null);
-        assertEquals(forbidTemplate.effect(), actualForbidValue);
+        assertEquals(forbidTemplate.effect(), Effect.FORBID);
 
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -123,8 +123,8 @@ public class PolicyTests {
             p.toJson();
         });
 
-        String actualPermitValue = "\"permit\"";
-        String actualForbidValue = "\"forbid\"";
+        String actualPermitValue = "permit";
+        String actualForbidValue = "forbid";
 
         // Tests for static policies
         Policy permitPolicy = new Policy("permit(principal, action, resource);", null);

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -405,11 +405,8 @@ fn policy_effect_jni_internal<'a>(
         let policy_jstring = env.get_string(&policy_jstr)?;
         let policy_string = String::from(policy_jstring);
         let policy = Policy::from_str(&policy_string)?;
-        let policy_effect = serde_json::to_string(&policy.effect())?;
-        let policy_effect_unquoted: &str = serde_json::from_str(&policy_effect)?;
-        Ok(JValueGen::Object(
-            env.new_string(&policy_effect_unquoted)?.into(),
-        ))
+        let policy_effect = policy.effect().to_string();
+        Ok(JValueGen::Object(env.new_string(&policy_effect)?.into()))
     }
 }
 
@@ -431,11 +428,8 @@ fn template_effect_jni_internal<'a>(
         let policy_jstring = env.get_string(&policy_jstr)?;
         let policy_string = String::from(policy_jstring);
         let policy = Template::from_str(&policy_string)?;
-        let policy_effect = serde_json::to_string(&policy.effect())?;
-        let policy_effect_unquoted: &str = serde_json::from_str(&policy_effect)?;
-        Ok(JValueGen::Object(
-            env.new_string(&policy_effect_unquoted)?.into(),
-        ))
+        let policy_effect = policy.effect().to_string();
+        Ok(JValueGen::Object(env.new_string(&policy_effect)?.into()))
     }
 }
 

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -406,7 +406,10 @@ fn policy_effect_jni_internal<'a>(
         let policy_string = String::from(policy_jstring);
         let policy = Policy::from_str(&policy_string)?;
         let policy_effect = serde_json::to_string(&policy.effect())?;
-        Ok(JValueGen::Object(env.new_string(&policy_effect)?.into()))
+        let policy_effect_unquoted: &str = serde_json::from_str(&policy_effect)?;
+        Ok(JValueGen::Object(
+            env.new_string(&policy_effect_unquoted)?.into(),
+        ))
     }
 }
 
@@ -429,7 +432,10 @@ fn template_effect_jni_internal<'a>(
         let policy_string = String::from(policy_jstring);
         let policy = Template::from_str(&policy_string)?;
         let policy_effect = serde_json::to_string(&policy.effect())?;
-        Ok(JValueGen::Object(env.new_string(&policy_effect)?.into()))
+        let policy_effect_unquoted: &str = serde_json::from_str(&policy_effect)?;
+        Ok(JValueGen::Object(
+            env.new_string(&policy_effect_unquoted)?.into(),
+        ))
     }
 }
 

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -388,6 +388,52 @@ fn to_json_internal<'a>(env: &mut JNIEnv<'a>, policy_jstr: JString<'a>) -> Resul
 }
 
 #[jni_fn("com.cedarpolicy.model.policy.Policy")]
+pub fn policyEffectJni<'a>(mut env: JNIEnv<'a>, _: JClass, policy_jstr: JString<'a>) -> jvalue {
+    match policy_effect_jni_internal(&mut env, policy_jstr) {
+        Err(e) => jni_failed(&mut env, e.as_ref()),
+        Ok(effect) => effect.as_jni(),
+    }
+}
+
+fn policy_effect_jni_internal<'a>(
+    env: &mut JNIEnv<'a>,
+    policy_jstr: JString<'a>,
+) -> Result<JValueOwned<'a>> {
+    if policy_jstr.is_null() {
+        raise_npe(env)
+    } else {
+        let policy_jstring = env.get_string(&policy_jstr)?;
+        let policy_string = String::from(policy_jstring);
+        let policy = Policy::from_str(&policy_string)?;
+        let policy_effect = serde_json::to_string(&policy.effect())?;
+        Ok(JValueGen::Object(env.new_string(&policy_effect)?.into()))
+    }
+}
+
+#[jni_fn("com.cedarpolicy.model.policy.Policy")]
+pub fn templateEffectJni<'a>(mut env: JNIEnv<'a>, _: JClass, policy_jstr: JString<'a>) -> jvalue {
+    match template_effect_jni_internal(&mut env, policy_jstr) {
+        Err(e) => jni_failed(&mut env, e.as_ref()),
+        Ok(effect) => effect.as_jni(),
+    }
+}
+
+fn template_effect_jni_internal<'a>(
+    env: &mut JNIEnv<'a>,
+    policy_jstr: JString<'a>,
+) -> Result<JValueOwned<'a>> {
+    if policy_jstr.is_null() {
+        raise_npe(env)
+    } else {
+        let policy_jstring = env.get_string(&policy_jstr)?;
+        let policy_string = String::from(policy_jstring);
+        let policy = Template::from_str(&policy_string)?;
+        let policy_effect = serde_json::to_string(&policy.effect())?;
+        Ok(JValueGen::Object(env.new_string(&policy_effect)?.into()))
+    }
+}
+
+#[jni_fn("com.cedarpolicy.model.policy.Policy")]
 pub fn fromJsonJni<'a>(mut env: JNIEnv<'a>, _: JClass, policy_json_jstr: JString<'a>) -> jvalue {
     match from_json_internal(&mut env, policy_json_jstr) {
         Err(e) => jni_failed(&mut env, e.as_ref()),


### PR DESCRIPTION
## Description of Changes
This PR adds functionality to expose the `effect` of Cedar policies, aligning with the capabilities available in Cedar Rust's [`Policy`](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Policy.html#method.effect) and [`Template`](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Template.html#method.effect) implementations.

## Changes
- Implements `effect()` method to determine if a policy is a `"permit"` or `"forbid"` policy
- Exposes `effect` for both static policies and templates
- Adds unit tests

## Implementation Note
Cedar Java currently uses a unified `Policy` class for both static policies and templates, unlike Cedar Rust which separates these concerns into distinct `Policy` and `Template` structs. To maintain compatibility while exposing this functionality:

1. The `effect()` method first attempts to parse the input as a static policy and gets the effect
2. If getting the effect as static policy fails, it attempts to parse as a template
3. Returns the appropriate effect based on the successful parse

## Future Considerations
Refactor Cedar Java to mirror Cedar Rust's separation of `Policy` and `Template` into distinct classes, allowing for better handling of each policy type.