### PR TITLE
Adds getter methods for PolicySet and Entity

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/entity/Entity.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/entity/Entity.java
@@ -66,6 +66,20 @@ public class Entity {
         this.tags = new HashMap<>(tags);
     }
 
+    /**
+     * Get the value for the given attribute, or null if not present.
+     * 
+     * @param attribute Attribute key
+     * @return Attribute value for the given key or null if not present
+     * @throws IllegalArgumentException if attribute is null
+     */
+    public Value getAttr(String attribute) {
+        if (attribute == null) {
+            throw new IllegalArgumentException("Attribute key cannot be null");
+        }
+        return this.attrs.getOrDefault(attribute, null);
+    }
+
     @Override
     public String toString() {
         String parentStr = "";

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
@@ -86,6 +86,24 @@ public class PolicySet {
     }
 
     /**
+     * Gets number of static policies in the Policy Set.
+     * 
+     * @return number of static policies, returns 0 if policies set is null
+     */
+    public int getNumPolicies() {
+        return policies != null ? policies.size() : 0;
+    } 
+
+    /**
+     * Gets number of templates in the Policy Set.
+     * 
+     * @return number of templates, returns 0 if templates set is null
+     */
+    public int getNumTemplates() {
+        return templates != null ? templates.size() : 0;
+    }
+
+    /**
      * Parse multiple policies and templates from a file into a PolicySet.
      * @param filePath the path to the file containing the policies
      * @return a PolicySet containing the parsed policies

--- a/CedarJava/src/test/java/com/cedarpolicy/EntityTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntityTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package com.cedarpolicy;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cedarpolicy.value.*;
+import com.cedarpolicy.model.entity.Entity;
+
+
+public class EntityTests {
+
+    @Test
+    public void getAttrTests() {
+
+
+        PrimString stringAttr = new PrimString("stringAttrValue");
+        HashMap<String, Value> attrs = new HashMap<>();
+        attrs.put("stringAttr", stringAttr);
+        EntityTypeName principalType = EntityTypeName.parse("User").get();
+        Entity principal = new Entity(principalType.of("Alice"), attrs, new HashSet<>());
+
+        // Test valid attribute key and value
+        assertEquals(principal.getAttr("stringAttr"), stringAttr);
+
+        // Test invalid attribute key
+        assertThrows(IllegalArgumentException.class, () -> {
+            principal.getAttr(null);
+        });
+
+        // Test key not found
+        assertEquals(principal.getAttr("decimalAttr"), null);
+
+    }
+}

--- a/CedarJava/src/test/java/com/cedarpolicy/EntityTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntityTests.java
@@ -32,8 +32,6 @@ public class EntityTests {
 
     @Test
     public void getAttrTests() {
-
-
         PrimString stringAttr = new PrimString("stringAttrValue");
         HashMap<String, Value> attrs = new HashMap<>();
         attrs.put("stringAttr", stringAttr);
@@ -50,6 +48,5 @@ public class EntityTests {
 
         // Test key not found
         assertEquals(principal.getAttr("decimalAttr"), null);
-
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
@@ -85,7 +85,6 @@ public class PolicySetTests {
 
     @Test
     public void getNumTests() throws InternalException, IOException {
-
         // Null policy set
         PolicySet nullPolicySet = new PolicySet(null, null, null);
         assertEquals(0, nullPolicySet.getNumPolicies());
@@ -100,6 +99,5 @@ public class PolicySetTests {
         PolicySet policySet = PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "template.cedar"));
         assertEquals(2, policySet.getNumPolicies());
         assertEquals(1, policySet.getNumTemplates());
-
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
@@ -82,4 +82,24 @@ public class PolicySetTests {
             PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "malformed_policy_set.cedar"));
         });
     }
+
+    @Test
+    public void getNumTests() throws InternalException, IOException {
+
+        // Null policy set
+        PolicySet nullPolicySet = new PolicySet(null, null, null);
+        assertEquals(0, nullPolicySet.getNumPolicies());
+        assertEquals(0, nullPolicySet.getNumTemplates());
+
+        // Empty policy set
+        PolicySet emptyPolicySet = new PolicySet();
+        assertEquals(0, emptyPolicySet.getNumPolicies());
+        assertEquals(0, emptyPolicySet.getNumTemplates());
+
+        // Non-empty policy set
+        PolicySet policySet = PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "template.cedar"));
+        assertEquals(2, policySet.getNumPolicies());
+        assertEquals(1, policySet.getNumTemplates());
+
+    }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -111,7 +111,8 @@ public class PolicyTests {
         assertEquals(validJson, actualJson);
     }
 
-    @Test void policyEffectTest() throws InternalException {
+    @Test
+    public void policyEffectTest() throws InternalException {
 
         assertThrows(NullPointerException.class, () -> {
             Policy p = new Policy(null, null);


### PR DESCRIPTION
## Description of changes ##
- Adds the following getter methods:
  - Entity.getAttr [Rust_equivalent](https://docs.rs/cedar-policy/4.2.2/cedar_policy/struct.Entity.html#method.attr)
  - PolicySet.getNumPolicies [Rust_equivalent](https://docs.rs/cedar-policy/4.2.2/cedar_policy/struct.PolicySet.html#method.num_of_policies)
  - PolicySet.getNumTemplates [Rust_equivalent](https://docs.rs/cedar-policy/4.2.2/cedar_policy/struct.PolicySet.html#method.num_of_templates)
- Adds unit tests for the getter methods
- Adds explicit scope modifier for policyEffectTest

_Note:_ 
While fields are currently public, these getters lay groundwork for future encapsulation:
  - Will enable transition of fields to private access
  - Establishes consistent getter/setter pattern aligned with Cedar Rust implementation
  - Preserves API compatibility through abstraction layer allowing us to add functionality without any breaking changes


