### PR TITLE
Adds PolicySet .toJson

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/CedarJson.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/CedarJson.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
-final class CedarJson {
+public final class CedarJson {
     private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
 
     private CedarJson() {
@@ -41,7 +41,7 @@ final class CedarJson {
     }
 
     public static ObjectMapper objectMapper() {
-        return OBJECT_MAPPER;
+        return OBJECT_MAPPER.copy();
     }
 
     public static ObjectWriter objectWriter() {

--- a/CedarJava/src/main/java/com/cedarpolicy/model/entity/Entity.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/entity/Entity.java
@@ -68,7 +68,7 @@ public class Entity {
 
     /**
      * Get the value for the given attribute, or null if not present.
-     * 
+     *
      * @param attribute Attribute key
      * @return Attribute value for the given key or null if not present
      * @throws IllegalArgumentException if attribute is null

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
@@ -16,8 +16,10 @@
 
 package com.cedarpolicy.model.policy;
 
+import static com.cedarpolicy.CedarJson.objectWriter;
 import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.model.exception.InternalException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.Collections;
 import java.util.List;
@@ -87,20 +89,32 @@ public class PolicySet {
 
     /**
      * Gets number of static policies in the Policy Set.
-     * 
+     *
      * @return number of static policies, returns 0 if policies set is null
      */
     public int getNumPolicies() {
         return policies != null ? policies.size() : 0;
-    } 
+    }
 
     /**
      * Gets number of templates in the Policy Set.
-     * 
+     *
      * @return number of templates, returns 0 if templates set is null
      */
     public int getNumTemplates() {
         return templates != null ? templates.size() : 0;
+    }
+
+    /**
+      * Converts the PolicySet object to a Cedar JSON string representation.
+      *
+      * @return Cedar JSON string representation of the PolicySet
+      * @throws InternalException if there is an error during JSON conversion in the Rust native code
+      * @throws JsonProcessingException if there is an error serializing the object to JSON
+      */
+      public String toJson() throws InternalException, JsonProcessingException {
+        String ffiCompatibleJson = objectWriter().writeValueAsString(this);
+        return policySetToJson(ffiCompatibleJson);
     }
 
     /**
@@ -130,4 +144,5 @@ public class PolicySet {
     }
 
     private static native PolicySet parsePoliciesJni(String policiesStr) throws InternalException, NullPointerException;
+    private static native String policySetToJson(String policySetJStr) throws InternalException, NullPointerException;
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
@@ -256,9 +257,9 @@ public class JSONTests {
 
     /** Tests deserialization of unknown value */
     @Test
-    public void testDeserializationUnknown() throws JsonProcessingException {
+    public void testDeserializationUnknown() throws JsonProcessingException, IOException {
         String json = "{\"__extn\":{\"fn\":\"unknown\",\"arg\":\"test\"}}";
-        Value value = CedarJson.objectMapper().readValue(json, Value.class);
+        Value value = CedarJson.objectReader().readValue(json, Value.class);
         assertInstanceOf(Unknown.class, value);
         Unknown unknown = (Unknown) value;
         assertEquals("test", unknown.toString());
@@ -266,10 +267,10 @@ public class JSONTests {
 
     /** Tests deserialization of value that causes stack overflow */
     @Test
-    public void testDeserializationStackOverflow() {
+    public void testDeserializationStackOverflow() throws IOException {
         String json = "{\"\":" + "[".repeat(1024) + "]".repeat(1024) + "}";
         try {
-            CedarJson.objectMapper().readValue(json, Value.class);
+            CedarJson.objectReader().readValue(json, Value.class);
         } catch (JsonProcessingException e) {
             System.out.println("class: " + e.getClass());
             assertTrue(e instanceof StreamConstraintsException);

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
@@ -23,10 +23,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.cedarpolicy.TestUtil.buildValidPolicySet;
+import static com.cedarpolicy.TestUtil.buildInvalidPolicySet;
 
 public class PolicySetTests {
     private static final String TEST_RESOURCES_DIR = "src/test/resources/";
@@ -99,5 +102,27 @@ public class PolicySetTests {
         PolicySet policySet = PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "template.cedar"));
         assertEquals(2, policySet.getNumPolicies());
         assertEquals(1, policySet.getNumTemplates());
+    }
+
+    @Test
+    public void policySetToJsonTests() throws JsonProcessingException, IOException, InternalException {
+        // Tests valid PolicySet
+        PolicySet validPolicySet = buildValidPolicySet();
+        String validJson = "{\"templates\":{\"t0\":{\"effect\":\"permit\",\"principal\":{\"op\":\"==\",\"slot\":\"?principal\"},"
+                + "\"action\":{\"op\":\"==\",\"entity\":{\"type\":\"Action\",\"id\":\"View_Photo\"}},"
+                + "\"resource\":{\"op\":\"in\",\"entity\":{\"type\":\"Album\",\"id\":\"Vacation\"}},\"conditions\":[]}},"
+                + "\"staticPolicies\":{\"p1\":{\"effect\":\"permit\",\"principal\":{\"op\":\"==\","
+                + "\"entity\":{\"type\":\"User\",\"id\":\"Bob\"}},"
+                + "\"action\":{\"op\":\"==\",\"entity\":{\"type\":\"Action\",\"id\":\"View_Photo\"}},"
+                + "\"resource\":{\"op\":\"in\",\"entity\":{\"type\":\"Album\",\"id\":\"Vacation\"}},\"conditions\":[]}},"
+                + "\"templateLinks\":[{\"templateId\":\"t0\",\"newId\":\"tl0\",\"values\":{\"?principal\":"
+                + "{\"__entity\":{\"type\":\"User\",\"id\":\"Alice\"}}}}]}";
+        assertEquals(validJson, validPolicySet.toJson());
+        
+        // Tests invalid PolicySet
+        PolicySet invalidPolicySet = buildInvalidPolicySet();
+        assertThrows(InternalException.class, () -> {
+            invalidPolicySet.toJson();
+        });
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/TestUtil.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/TestUtil.java
@@ -18,11 +18,21 @@ package com.cedarpolicy;
 
 import com.cedarpolicy.model.schema.Schema;
 import com.cedarpolicy.model.schema.Schema.JsonOrCedar;
+import com.cedarpolicy.model.policy.TemplateLink;
+import com.cedarpolicy.model.policy.PolicySet;
+import com.cedarpolicy.model.policy.LinkValue;
+import com.cedarpolicy.model.policy.Policy;
+import com.cedarpolicy.model.entity.Entity;
+import com.cedarpolicy.value.EntityTypeName;
 
+import java.util.HashSet;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
 
 /** Utils to help with tests. */
 public final class TestUtil {
@@ -45,4 +55,57 @@ public final class TestUtil {
             throw new RuntimeException("Failed to load test schema file " + schemaFile, e);
         }
     }
+
+    public static PolicySet buildValidPolicySet() {
+        EntityTypeName principalType = EntityTypeName.parse("User").get();
+        Set<Policy> policies = new HashSet<>();
+        Set<Policy> templates = new HashSet<>();
+        ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>(); 
+        ArrayList<LinkValue> linkValueList = new ArrayList<>();
+
+        String fullPolicy =
+                "permit(principal == User::\"Bob\", action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
+        Policy newPolicy = new Policy(fullPolicy, "p1");
+        policies.add(newPolicy);
+
+        String template = "permit(principal == ?principal, action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
+        Policy policyTemplate = new Policy(template, "t0");
+        templates.add(policyTemplate);
+
+        Entity principal = new Entity(principalType.of("Alice"), new HashMap<>(), new HashSet<>());
+        LinkValue principalLinkValue = new LinkValue("?principal", principal.getEUID());
+        linkValueList.add(principalLinkValue);
+
+        TemplateLink templateLink = new TemplateLink("t0", "tl0", linkValueList);
+        templateLinks.add(templateLink);
+
+        return new PolicySet(policies, templates, templateLinks);
+    }
+
+    public static PolicySet buildInvalidPolicySet() {
+        EntityTypeName principalType = EntityTypeName.parse("User").get();
+        Set<Policy> policies = new HashSet<>();
+        Set<Policy> templates = new HashSet<>();
+        ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>(); 
+        ArrayList<LinkValue> linkValueList = new ArrayList<>();
+
+        String fullPolicy =
+                "permit(prinipal == User::\"Bob\", action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
+        Policy newPolicy = new Policy(fullPolicy, "p1");
+        policies.add(newPolicy);
+
+        String template = "permit(principal, action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
+        Policy policyTemplate = new Policy(template, "t0");
+        templates.add(policyTemplate);
+
+        Entity principal = new Entity(principalType.of("Alice"), new HashMap<>(), new HashSet<>());
+        LinkValue principalLinkValue = new LinkValue("?principal", principal.getEUID());
+        linkValueList.add(principalLinkValue);
+
+        TemplateLink templateLink = new TemplateLink("t0", "tl0", linkValueList);
+        templateLinks.add(templateLink);
+
+        return new PolicySet(policies, templates, templateLinks);
+    }
+
 }


### PR DESCRIPTION
# Description of Changes
- Adds .toJson for PolicySet and corresponding FFI functions
- Adds unit tests for .toJson
- Changes visibility of CedarJson to public and add modifications to comply with `spotbugs`
- Modifies JSONTests to use immutable `ObjectReader` instead of `ObjectMapper` for CedarJson

Note:
This change depends on this [PR](https://github.com/cedar-policy/cedar/pull/1440) which exposes `ffi::PolicySet .parse()` in `cedar_policy`
