### PR TITLE
Creates Backward Compatible Context Class

### DIFF
--- a/CedarJava/.gitignore
+++ b/CedarJava/.gitignore
@@ -13,6 +13,6 @@
 .factorypath
 .project
 .settings/
-
+bin/
 # Ignore changes to gradle.properties because we enter passwords here for releases
 /gradle.properties

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationRequest.java
@@ -98,7 +98,7 @@ public class AuthorizationRequest {
     /**
      * Create an authorization request from the EUIDs and Context.
      * Constructor overloading to support Context object while preserving backward compatability.
-     * checked
+     *
      * @param principalEUID Principal's EUID.
      * @param actionEUID Action's EUID.
      * @param resourceEUID Resource's EUID.
@@ -144,7 +144,7 @@ public class AuthorizationRequest {
     /**
      * Create a request without a schema.
      * Constructor overloading to support Context object while preserving backward compatability.
-     * Checked
+     *
      * @param principalEUID Principal's EUID.
      * @param actionEUID Action's EUID.
      * @param resourceEUID Resource's EUID.
@@ -179,7 +179,7 @@ public class AuthorizationRequest {
     /**
      * Create a request without a schema, using Entity objects for principal/action/resource.
      * Constructor overloading to support Context object while preserving backward compatability.
-     * checked
+     *
      * @param principalEUID Principal's EUID.
      * @param actionEUID Action's EUID.
      * @param resourceEUID Resource's EUID.
@@ -222,7 +222,7 @@ public class AuthorizationRequest {
     /**
      * Create a request from Entity objects and Context.
      * Constructor overloading to support Context object while preserving backward compatability.
-     * checked
+     *
      * @param principal
      * @param action
      * @param resource

--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationRequest.java
@@ -96,6 +96,34 @@ public class AuthorizationRequest {
     }
 
     /**
+     * Create an authorization request from the EUIDs and Context.
+     * Constructor overloading to support Context object while preserving backward compatability.
+     * checked
+     * @param principalEUID Principal's EUID.
+     * @param actionEUID Action's EUID.
+     * @param resourceEUID Resource's EUID.
+     * @param context Context object.
+     * @param schema Schema (optional).
+     * @param enableRequestValidation Whether to use the schema for just
+     * schema-based parsing of `context` (false) or also for request validation
+     * (true). No effect if `schema` is not provided.
+     */
+    public AuthorizationRequest(
+        EntityUID principalEUID,
+        EntityUID actionEUID,
+        EntityUID resourceEUID,
+        Context context,
+        Optional<Schema> schema,
+        boolean enableRequestValidation) {
+    this.principalEUID = principalEUID;
+    this.actionEUID = actionEUID;
+    this.resourceEUID = resourceEUID;
+    this.context = Optional.of(context.getContext());
+    this.schema = schema;
+    this.enableRequestValidation = enableRequestValidation;
+}
+
+    /**
      * Create a request without a schema.
      *
      * @param principalEUID Principal's EUID.
@@ -109,6 +137,25 @@ public class AuthorizationRequest {
                 actionEUID,
                 resourceEUID,
                 Optional.of(context),
+                Optional.empty(),
+                false);
+    }
+
+    /**
+     * Create a request without a schema.
+     * Constructor overloading to support Context object while preserving backward compatability.
+     * Checked
+     * @param principalEUID Principal's EUID.
+     * @param actionEUID Action's EUID.
+     * @param resourceEUID Resource's EUID.
+     * @param context Key/Value context.
+     */
+    public AuthorizationRequest(EntityUID principalEUID, EntityUID actionEUID, EntityUID resourceEUID, Context context) {
+        this(
+                principalEUID,
+                actionEUID,
+                resourceEUID,
+                context,
                 Optional.empty(),
                 false);
     }
@@ -128,6 +175,24 @@ public class AuthorizationRequest {
                 resourceEUID.getEUID(),
                 context);
     }
+
+    /**
+     * Create a request without a schema, using Entity objects for principal/action/resource.
+     * Constructor overloading to support Context object while preserving backward compatability.
+     * checked
+     * @param principalEUID Principal's EUID.
+     * @param actionEUID Action's EUID.
+     * @param resourceEUID Resource's EUID.
+     * @param context Key/Value context.
+     */
+    public AuthorizationRequest(Entity principalEUID, Entity actionEUID, Entity resourceEUID, Context context) {
+        this(
+                principalEUID.getEUID(),
+                actionEUID.getEUID(),
+                resourceEUID.getEUID(),
+                context);
+    }
+
 
     /**
      * Create a request from Entity objects and Context.
@@ -154,6 +219,31 @@ public class AuthorizationRequest {
         );
     }
 
+    /**
+     * Create a request from Entity objects and Context.
+     * Constructor overloading to support Context object while preserving backward compatability.
+     * checked
+     * @param principal
+     * @param action
+     * @param resource
+     * @param context
+     * @param schema
+     * @param enableRequestValidation Whether to use the schema for just
+     * schema-based parsing of `context` (false) or also for request validation
+     * (true). No effect if `schema` is not provided.
+     */
+
+    public AuthorizationRequest(Entity principal, Entity action, Entity resource,
+                                Context context, Optional<Schema> schema, boolean enableRequestValidation) {
+        this(
+            principal.getEUID(),
+            action.getEUID(),
+            resource.getEUID(),
+            context,
+            schema,
+            enableRequestValidation
+        );
+    }
 
     /** Readable string representation. */
     @Override

--- a/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
@@ -51,7 +51,7 @@ public class Context {
     @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     public Context(Iterable<Map.Entry<String, Value>> contextList) {
         context = new HashMap<>();
-        mergeContextfromIterable(contextList);
+        mergeContextFromIterable(contextList);
     }
 
     /**
@@ -83,7 +83,7 @@ public class Context {
      * @throws IllegalArgumentException if the contextToMerge parameter is null
      */
     public void merge(Context contextToMerge) throws IllegalStateException, IllegalArgumentException {
-        mergeContextfromIterable(contextToMerge.getContext().entrySet());
+        mergeContextFromIterable(contextToMerge.getContext().entrySet());
     }
 
     /**
@@ -96,7 +96,7 @@ public class Context {
      */
     public void merge(Iterable<Map.Entry<String, Value>> contextMaps)
             throws IllegalStateException, IllegalArgumentException {
-        mergeContextfromIterable(contextMaps);
+        mergeContextFromIterable(contextMaps);
     }
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
@@ -1,0 +1,82 @@
+/*
+* Copyright Cedar Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.cedarpolicy.model;
+
+import java.util.HashMap;
+import java.util.Collections;
+import java.util.Collections.singletonMap;
+import java.util.Map;
+import java.util.List;
+import com.cedarpolicy.value.Value;
+
+
+public class Context {
+
+    private Map<String, Value> context;
+
+    /**
+     * Counterpart to empty() in CedarRust
+     */
+    public Context() {
+        this.context = Collections.emptyMap();
+    }
+
+    /**
+     * Counterpart to pairs() in CedarRust
+     * @param contextList
+     */
+    public Context(Iterable<singletonMap<String, Value>> contextList) {
+        this.context = new HashMap<>();
+        fromIterable();
+    }
+
+    /**
+     * Create a context object using a Map
+     * 
+     * @param contextMap
+     */
+    public Context(Map<String, Value> contextMap) {
+        this.context = new HashMap<>();
+        this.context.putAll(contextMap);
+    }
+
+    def getContextMap() {
+        return this.context.copy();
+    }
+
+    def merge(Context contextToMerge) {
+        this.context.putAll(contextToMerge.getContextMap());
+    }
+
+    /**
+     * Merges multiple maps of context values into this context
+     * @param contextMaps Iterator of Map<String,Value> to merge
+     */
+    public void merge(Iterable<singletonMap<String,Value>> contextMaps) {
+        fromIterable(contextMaps);
+    }
+
+    private fromIterable(Iterable<singletonMap<String,Value>> contextIterator) {
+        contextIterator.forEach(map -> {
+            if (!this.context.containsKey(map.keySet())) {
+                this.context.putAll(map);
+            } else {
+                throw new IllegalArgumentException("Duplicate key found in context");
+            }
+        });}
+
+    }

--- a/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
@@ -37,6 +37,10 @@ public class Context {
         context = Collections.emptyMap();
     }
 
+    public boolean isEmpty() {
+        return context.isEmpty();
+    }
+
     /**
      * Constructs a new Context from an Iterable of key-value pairs.
      * Creates a new HashMap and populates it with the provided entries.
@@ -69,7 +73,7 @@ public class Context {
      * 
      * @return A new HashMap containing all key-value pairs from the internal context
      */
-     public Map<String, Value> getContextMap() {
+     public Map<String, Value> getContext() {
         return new HashMap<>(context);
     }
 
@@ -81,7 +85,7 @@ public class Context {
      * @throws IllegalArgumentException if the contextToMerge parameter is null
      */
     public void merge(Context contextToMerge) throws IllegalStateException, IllegalArgumentException {
-        fromIterable(contextToMerge.getContextMap().entrySet());
+        fromIterable(contextToMerge.getContext().entrySet());
     }
 
     /**
@@ -136,5 +140,11 @@ public class Context {
                 Map.Entry::getValue
             ));
         context.putAll(newEntries);
+    }
+
+    /** Readable string representation. */
+    @Override
+    public String toString() {
+        return context.toString();
     }
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
@@ -122,7 +122,7 @@ public class Context {
      *                                  within the iterable
      * @throws IllegalArgumentException if the contextIterator is null
      */
-    private void mergeContextfromIterable(Iterable<Map.Entry<String, Value>> contextIterator)
+    private void mergeContextFromIterable(Iterable<Map.Entry<String, Value>> contextIterator)
             throws IllegalStateException, IllegalArgumentException {
         if (contextIterator == null) {
             throw new IllegalArgumentException("Context iterator cannot be null");

--- a/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
@@ -24,14 +24,13 @@ import java.util.Map;
 import com.cedarpolicy.value.Value;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-
 public class Context {
 
     private Map<String, Value> context;
 
     /**
-     * Constructs a new empty Context with no key-value pairs.
-     * Initializes the internal context map as an empty immutable map.
+     * Constructs a new empty Context with no key-value pairs. Initializes the internal context map as an empty
+     * immutable map.
      */
     public Context() {
         context = Collections.emptyMap();
@@ -42,23 +41,22 @@ public class Context {
     }
 
     /**
-     * Constructs a new Context from an Iterable of key-value pairs.
-     * Creates a new HashMap and populates it with the provided entries.
-     * Equivalent to from_pairs in Cedar Rust.
+     * Constructs a new Context from an Iterable of key-value pairs. Creates a new HashMap and populates it with the
+     * provided entries. Equivalent to from_pairs in Cedar Rust.
      *
      * @param contextList An Iterable containing key-value pairs to initialize this context with
-     * @throws IllegalStateException if a duplicate key is found within the iterable
+     * @throws IllegalStateException    if a duplicate key is found within the iterable
      * @throws IllegalArgumentException if the contextList parameter is null
      */
     @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     public Context(Iterable<Map.Entry<String, Value>> contextList) {
         context = new HashMap<>();
-        fromIterable(contextList);
+        mergeContextfromIterable(contextList);
     }
 
     /**
-     * Constructs a new Context with the provided map of key-value pairs.
-     * Creates a defensive copy of the input map to maintain immutability.
+     * Constructs a new Context with the provided map of key-value pairs. Creates a defensive copy of the input map to
+     * maintain immutability.
      *
      * @param contextMap The map of key-value pairs to initialize this context with
      * @throws IllegalArgumentException if the contextMap parameter is null
@@ -73,7 +71,7 @@ public class Context {
      *
      * @return A new HashMap containing all key-value pairs from the internal context
      */
-     public Map<String, Value> getContext() {
+    public Map<String, Value> getContext() {
         return new HashMap<>(context);
     }
 
@@ -81,29 +79,32 @@ public class Context {
      * Merges another Context object into the current context.
      *
      * @param contextToMerge The Context object to merge into this context
-     * @throws IllegalStateException if a duplicate key is found while merging the context
+     * @throws IllegalStateException    if a duplicate key is found while merging the context
      * @throws IllegalArgumentException if the contextToMerge parameter is null
      */
     public void merge(Context contextToMerge) throws IllegalStateException, IllegalArgumentException {
-        fromIterable(contextToMerge.getContext().entrySet());
+        mergeContextfromIterable(contextToMerge.getContext().entrySet());
     }
 
     /**
      * Merges the provided key-value pairs into the current context.
      *
      * @param contextMaps An Iterable containing key-value pairs to merge into this context
-     * @throws IllegalStateException if a duplicate key is found in the existing context or duplicate key found within the iterable
+     * @throws IllegalStateException    if a duplicate key is found in the existing context or duplicate key found
+     *                                  within the iterable
      * @throws IllegalArgumentException if the contextMaps parameter is null
      */
-    public void merge(Iterable<Map.Entry<String, Value>> contextMaps) throws IllegalStateException, IllegalArgumentException {
-        fromIterable(contextMaps);
+    public void merge(Iterable<Map.Entry<String, Value>> contextMaps)
+            throws IllegalStateException, IllegalArgumentException {
+        mergeContextfromIterable(contextMaps);
     }
 
     /**
      * Retrieves the Value associated with the specified key from the context.
      *
      * @param key The key whose associated Value is to be returned
-     * @return The Value associated with the specified key, or null if the key is not found replicating Cedar Rust behavior
+     * @return The Value associated with the specified key, or null if the key is not found replicating Cedar Rust
+     *         behavior
      * @throws IllegalArgumentException if the key parameter is null
      */
     public Value get(String key) {
@@ -117,26 +118,22 @@ public class Context {
      * Processes an Iterable of Map entries and adds them to the context.
      *
      * @param contextIterator The Iterable containing key-value pairs to add to the context
-     * @throws IllegalStateException if a duplicate key is found in the existing context or duplicate key found within the iterable
+     * @throws IllegalStateException    if a duplicate key is found in the existing context or duplicate key found
+     *                                  within the iterable
      * @throws IllegalArgumentException if the contextIterator is null
      */
-    private void fromIterable(Iterable<Map.Entry<String, Value>> contextIterator) throws IllegalStateException, IllegalArgumentException {
+    private void mergeContextfromIterable(Iterable<Map.Entry<String, Value>> contextIterator)
+            throws IllegalStateException, IllegalArgumentException {
         if (contextIterator == null) {
             throw new IllegalArgumentException("Context iterator cannot be null");
         }
 
-        Map<String, Value> newEntries = StreamSupport.stream(contextIterator.spliterator(), false)
-            .peek(entry -> {
-                if (context.containsKey(entry.getKey())) {
-                    throw new IllegalStateException(
-                        String.format("Duplicate key '%s' in existing context", entry.getKey())
-                    );
-                }
-            })
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue
-            ));
+        Map<String, Value> newEntries = StreamSupport.stream(contextIterator.spliterator(), false).peek(entry -> {
+            if (context.containsKey(entry.getKey())) {
+                throw new IllegalStateException(
+                        String.format("Duplicate key '%s' in existing context", entry.getKey()));
+            }
+        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         context.putAll(newEntries);
     }
 

--- a/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/Context.java
@@ -50,7 +50,7 @@ public class Context {
      * @throws IllegalStateException if a duplicate key is found within the iterable
      * @throws IllegalArgumentException if the contextList parameter is null
      */
-    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW") 
+    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     public Context(Iterable<Map.Entry<String, Value>> contextList) {
         context = new HashMap<>();
         fromIterable(contextList);
@@ -70,7 +70,7 @@ public class Context {
 
     /**
      * Returns a defensive copy of the internal context map.
-     * 
+     *
      * @return A new HashMap containing all key-value pairs from the internal context
      */
      public Map<String, Value> getContext() {
@@ -79,7 +79,7 @@ public class Context {
 
     /**
      * Merges another Context object into the current context.
-     * 
+     *
      * @param contextToMerge The Context object to merge into this context
      * @throws IllegalStateException if a duplicate key is found while merging the context
      * @throws IllegalArgumentException if the contextToMerge parameter is null
@@ -90,7 +90,7 @@ public class Context {
 
     /**
      * Merges the provided key-value pairs into the current context.
-     * 
+     *
      * @param contextMaps An Iterable containing key-value pairs to merge into this context
      * @throws IllegalStateException if a duplicate key is found in the existing context or duplicate key found within the iterable
      * @throws IllegalArgumentException if the contextMaps parameter is null
@@ -99,11 +99,9 @@ public class Context {
         fromIterable(contextMaps);
     }
 
-
-
     /**
      * Retrieves the Value associated with the specified key from the context.
-     * 
+     *
      * @param key The key whose associated Value is to be returned
      * @return The Value associated with the specified key, or null if the key is not found replicating Cedar Rust behavior
      * @throws IllegalArgumentException if the key parameter is null
@@ -117,7 +115,7 @@ public class Context {
 
     /**
      * Processes an Iterable of Map entries and adds them to the context.
-     * 
+     *
      * @param contextIterator The Iterable containing key-value pairs to add to the context
      * @throws IllegalStateException if a duplicate key is found in the existing context or duplicate key found within the iterable
      * @throws IllegalArgumentException if the contextIterator is null

--- a/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationRequest.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/PartialAuthorizationRequest.java
@@ -160,6 +160,11 @@ public class PartialAuthorizationRequest {
             return this;
         }
 
+        public Builder context(Context context) {
+            this.context = Optional.of(ImmutableMap.copyOf(context.getContext()));
+            return this;
+        }
+
         /**
          * Set the context to be empty, not unknown
          * @return The builder.

--- a/CedarJava/src/test/java/com/cedarpolicy/AuthTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/AuthTests.java
@@ -27,11 +27,13 @@ import com.cedarpolicy.model.AuthorizationSuccessResponse.Decision;
 import com.cedarpolicy.model.exception.MissingExperimentalFeatureException;
 import com.cedarpolicy.model.entity.Entity;
 import com.cedarpolicy.model.policy.Policy;
+import com.cedarpolicy.model.Context;
 import com.cedarpolicy.model.policy.PolicySet;
 import com.cedarpolicy.value.EntityTypeName;
 import com.cedarpolicy.value.EntityUID;
 import com.cedarpolicy.value.Unknown;
 import com.cedarpolicy.value.Value;
+import com.cedarpolicy.value.PrimBool;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -52,6 +54,7 @@ public class AuthTests {
         });
     }
 
+
     @Test
     public void simple() {
         var alice = new EntityUID(EntityTypeName.parse("User").get(), "alice");
@@ -61,6 +64,66 @@ public class AuthTests {
         policies.add(new Policy("permit(principal,action,resource);", "p0"));
         var policySet = new PolicySet(policies);
         assertAllowed(q, policySet, new HashSet<>());
+    }
+
+    private Set<Entity> buildEntitiesForContextTests() {
+        EntityTypeName principalType = EntityTypeName.parse("User").get();
+        EntityTypeName actionType = EntityTypeName.parse("Action").get();
+        EntityTypeName albumResourceType = EntityTypeName.parse("Album").get();
+        EntityTypeName photoResourceType = EntityTypeName.parse("Photo").get();
+
+        Set<EntityUID> parents = new HashSet<>();
+        Entity album = new Entity(albumResourceType.of("Vacation"), new HashMap<>(), new HashSet<>());
+        parents.add(album.getEUID());
+        Entity photo = new Entity(photoResourceType.of("pic01"), new HashMap<>(), parents);
+
+        Set<Entity> entities = new HashSet<>();
+        entities.add(photo);
+        entities.add(album);
+        entities.add(new Entity(principalType.of("Alice"), new HashMap<>(), new HashSet<>()));
+        entities.add(new Entity(actionType.of("View_Photo"), new HashMap<>(), new HashSet<>()));
+
+        return entities;
+    }
+
+    private PolicySet buildPolicySetForContextTests() {
+        Set<Policy> ps = new HashSet<>();
+        String fullPolicy =
+                "permit(principal == User::\"Alice\", action == Action::\"View_Photo\", resource in Album::\"Vacation\")"
+                + "when {context.authenticated == true};";
+
+        Policy newPolicy = new Policy(fullPolicy, "p1");
+        ps.add(newPolicy);
+        return new PolicySet(ps);
+    }
+
+    @Test
+    public void authWithBackwardCompatibleContext() {
+        EntityUID principal = new EntityUID(EntityTypeName.parse("User").get(), "Alice");
+        EntityUID action = new EntityUID(EntityTypeName.parse("Action").get(), "View_Photo");
+        EntityUID resource = new EntityUID(EntityTypeName.parse("Photo").get(), "pic01");
+        Set<Entity> entities = buildEntitiesForContextTests();
+        PolicySet policySet = buildPolicySetForContextTests();
+        Map<String, Value> context = new HashMap<>();
+        context.put("authenticated", new PrimBool(true));
+        AuthorizationRequest r = new AuthorizationRequest(principal, action, resource, context);
+
+        assertAllowed(r, policySet, entities);
+    }
+
+    @Test
+    public void authWithContextObject() {
+        EntityUID principal = new EntityUID(EntityTypeName.parse("User").get(), "Alice");
+        EntityUID action = new EntityUID(EntityTypeName.parse("Action").get(), "View_Photo");
+        EntityUID resource = new EntityUID(EntityTypeName.parse("Photo").get(), "pic01");
+        Set<Entity> entities = buildEntitiesForContextTests();
+        PolicySet policySet = buildPolicySetForContextTests();
+        Map<String, Value> contextMap = new HashMap<>();
+        contextMap.put("authenticated", new PrimBool(true));
+        Context context = new Context(contextMap);
+        AuthorizationRequest r = new AuthorizationRequest(principal, action, resource, context);
+        
+        assertAllowed(r, policySet, entities);
     }
 
     @Test

--- a/CedarJava/src/test/java/com/cedarpolicy/AuthTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/AuthTests.java
@@ -54,7 +54,6 @@ public class AuthTests {
         });
     }
 
-
     @Test
     public void simple() {
         var alice = new EntityUID(EntityTypeName.parse("User").get(), "alice");
@@ -152,12 +151,16 @@ public class AuthTests {
         var auth = new BasicAuthorizationEngine();
         var alice = new EntityUID(EntityTypeName.parse("User").get(), "alice");
         var view = new EntityUID(EntityTypeName.parse("Action").get(), "view");
+
         Map<String, Value> context = new HashMap<>();
         context.put("authenticated", new PrimBool(true));
+
         var q = PartialAuthorizationRequest.builder().principal(alice).action(view).resource(alice).context(context).build();
+        
         var policies = new HashSet<Policy>();
         policies.add(new Policy("permit(principal == User::\"alice\",action,resource) when {context.authenticated == true};", "p0"));
         var policySet = new PolicySet(policies);
+
         assumePartialEvaluation(() -> {
             try {
                 final PartialAuthorizationResponse response = auth.isAuthorizedPartial(q, policySet, new HashSet<>());

--- a/CedarJava/src/test/java/com/cedarpolicy/AuthTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/AuthTests.java
@@ -121,7 +121,7 @@ public class AuthTests {
         contextMap.put("authenticated", new PrimBool(true));
         Context context = new Context(contextMap);
         AuthorizationRequest r = new AuthorizationRequest(principal, action, resource, context);
-        
+
         assertAllowed(r, policySet, entities);
     }
 
@@ -156,7 +156,7 @@ public class AuthTests {
         context.put("authenticated", new PrimBool(true));
 
         var q = PartialAuthorizationRequest.builder().principal(alice).action(view).resource(alice).context(context).build();
-        
+
         var policies = new HashSet<Policy>();
         policies.add(new Policy("permit(principal == User::\"alice\",action,resource) when {context.authenticated == true};", "p0"));
         var policySet = new PolicySet(policies);
@@ -180,7 +180,7 @@ public class AuthTests {
         var view = new EntityUID(EntityTypeName.parse("Action").get(), "view");
         Map<String, Value> contextMap = new HashMap<>();
         contextMap.put("authenticated", new PrimBool(true));
-        Context context = new Context(contextMap); 
+        Context context = new Context(contextMap);
         var q = PartialAuthorizationRequest.builder().principal(alice).action(view).resource(alice).context(context).build();
         var policies = new HashSet<Policy>();
         policies.add(new Policy("permit(principal == User::\"alice\",action,resource) when {context.authenticated == true};", "p0"));

--- a/CedarJava/src/test/java/com/cedarpolicy/ContextTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/ContextTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cedarpolicy;
+
+import com.cedarpolicy.value.PrimBool;
+import com.cedarpolicy.value.PrimLong;
+import com.cedarpolicy.value.PrimString;
+import com.cedarpolicy.value.Value;
+import com.cedarpolicy.model.Context;
+
+import org.junit.jupiter.api.Test;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ContextTests {
+
+    private Map<String, Value> getValidMap() {
+        Map<String, Value> expectedContextMap = new HashMap<>();
+        expectedContextMap.put("key1", new PrimString("value1"));
+        expectedContextMap.put("key2", new PrimLong(999));
+        expectedContextMap.put("key3", new PrimBool(true));
+
+        return expectedContextMap;
+    }
+
+    private Map<String, Value> getValidMergedMap() {
+        Map<String, Value> expectedContextMap = new HashMap<>();
+        expectedContextMap.put("key1", new PrimString("value1"));
+        expectedContextMap.put("key2", new PrimLong(999));
+        expectedContextMap.put("key3", new PrimBool(true));
+        expectedContextMap.put("key4", new PrimString("value1"));
+        expectedContextMap.put("key5", new PrimLong(999));
+
+        return expectedContextMap;
+    }
+
+    private Iterable<Map.Entry<String, Value>> getValidIterable() {
+        Set<Map.Entry<String, Value>> iterableSet = new HashSet<>();
+        iterableSet.add(new AbstractMap.SimpleEntry<>("key1", new PrimString("value1")));
+        iterableSet.add(new AbstractMap.SimpleEntry<>("key2", new PrimLong(999)));
+        iterableSet.add(new AbstractMap.SimpleEntry<>("key3", new PrimBool(true)));
+
+        return iterableSet;
+    }
+
+    private Iterable<Map.Entry<String, Value>> getInvalidIterable() {
+        Set<Map.Entry<String, Value>> iterableSet = new HashSet<>();
+        iterableSet.add(new AbstractMap.SimpleEntry<>("key1", new PrimString("value1")));
+        iterableSet.add(new AbstractMap.SimpleEntry<>("key1", new PrimLong(999)));
+        iterableSet.add(new AbstractMap.SimpleEntry<>("key3", new PrimBool(true)));
+
+        return iterableSet;
+    }
+
+
+    @Test
+    public void givenValidIterableConstructorConstructs() throws IllegalStateException {
+        Context validContext = new Context(getValidIterable());
+        assertEquals(getValidMap(), validContext.getContext());
+    }
+
+    @Test
+    public void givenDuplicateKeyIterableConstructorThrows() throws IllegalStateException {
+        assertThrows(IllegalStateException.class, () -> {
+            Context validContext = new Context(getInvalidIterable());
+        });
+    }
+
+    @Test
+    public void givenValidMapConstructorConstructs() throws IllegalStateException {
+        Context validContext = new Context(getValidMap());
+
+        assertEquals(getValidMap(), validContext.getContext());
+    }
+
+    @Test
+    public void givenValidIterableMergeMerges() throws IllegalStateException {
+        Context validContext = new Context(getValidMap());
+        Map<String, Value> contextToMergeMap = new HashMap<>();
+        contextToMergeMap.put("key4", new PrimString("value1"));
+        contextToMergeMap.put("key5", new PrimLong(999));
+        validContext.merge(contextToMergeMap.entrySet());
+
+        assertEquals(getValidMergedMap(), validContext.getContext());
+    }
+
+    @Test
+    public void givenExistingKeyIterableMergeThrows() throws IllegalStateException {
+        Context context = new Context(getValidMap());
+        Map<String, Value> contextToMergeMap = new HashMap<>();
+        contextToMergeMap.put("key3", new PrimString("value1"));
+        contextToMergeMap.put("key5", new PrimLong(999));
+
+        assertThrows(IllegalStateException.class, () -> {
+            context.merge(contextToMergeMap.entrySet());
+        });
+    }
+
+    @Test
+    public void givenValidContextMergeMerges() throws IllegalStateException {
+        Context validContext = new Context(getValidMap());
+        Map<String, Value> contextToMergeMap = new HashMap<>();
+        contextToMergeMap.put("key4", new PrimString("value1"));
+        contextToMergeMap.put("key5", new PrimLong(999));
+        Context contextToMerge = new Context(contextToMergeMap);
+        validContext.merge(contextToMerge);
+
+        assertEquals(getValidMergedMap(), validContext.getContext());
+    }
+
+    @Test
+    public void givenExistingKeyContextMergeThrows() throws IllegalStateException {
+        Context validContext = new Context(getValidMap());
+        Map<String, Value> contextToMergeMap = new HashMap<>();
+        contextToMergeMap.put("key3", new PrimString("value1"));
+        contextToMergeMap.put("key5", new PrimLong(999));
+        Context contextToMerge = new Context(contextToMergeMap);
+
+        assertThrows(IllegalStateException.class, () -> {
+            validContext.merge(contextToMerge);
+        });
+    }
+
+    @Test
+    public void givenValidKeyGetReturnsValue() {
+        Context validContext = new Context(getValidMap());
+
+        assertEquals(getValidMap().get("key1"), validContext.get("key1"));
+    }
+
+    @Test
+    public void givenInvalidKeyGetReturnsNull() {
+        Context validContext = new Context(getValidMap());
+
+        assertEquals(null, validContext.get("invalidKey"));
+    }
+}


### PR DESCRIPTION
# Description
1. Currently, CedarJava handles Context as `Map<String,Value>` without a dedicated class. This PR creates Java equivalent class for [Context](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Context.html).
2. Implements methods to create and merge Contexts within CedarJava. Currently, does not implement from_* methods.
3. Uses method overloading to make it backward compatible in authorization requests.
4. Implements tests for Context. 
5. Implements tests to verify backward compatibility in AuthorizationRequest and PartialAuthorizationRequest.

_Future Consideration_:
- Create `.copy()` for all classes that implement `Value` interface. This will allow us to create deep-copy of any object that use `Value`. Currently, we can only create shallow copies for objects such as `Context`. For example, `.getContext()` creates and returns a shallow copy of the `Map<String, Value> context` but the `Value` object can potentially be modified. 
