### PR TITLE
Add JVM to enable testing of CedarJavaFFI interface methods

### DIFF
--- a/CedarJavaFFI/Cargo.toml
+++ b/CedarJavaFFI/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = "2.0"
 itertools = "0.14"
 
 # JNI Support
-jni = "0.21.0"
+jni = { version = "0.21.1", features = ["invocation"] }
 jni_fn = "0.1.0"
 
 [features]

--- a/CedarJavaFFI/Cargo.toml
+++ b/CedarJavaFFI/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = "2.0"
 itertools = "0.14"
 
 # JNI Support
-jni = { version = "0.21.1", features = ["invocation"] }
+jni = "0.21.1"
 jni_fn = "0.1.0"
 
 [features]
@@ -23,6 +23,7 @@ partial-eval = ["cedar-policy/partial-eval"]
 
 [dev-dependencies]
 cool_asserts = "2.0"
+jni = { version = "0.21.1", features = ["invocation"] }
 
 # Dynamic linked library, used for linked to java process at runtime.
 [lib]

--- a/CedarJavaFFI/README.md
+++ b/CedarJavaFFI/README.md
@@ -22,6 +22,8 @@ You can test the code with
 cargo test
 ```
 
+To test methods in `interface.rs`, the code creates a JVM instance. If you encounter errors indicating that Java cannot be found, verify that the `JAVA_HOME` environment variable is properly set on your system. For more details about JVM initialization from Rust, see the [jni crate documentation](https://docs.rs/jni/latest/jni/struct.JavaVM.html#launching-jvm-from-rust).
+
 Typically you will want to use `../CedarJava` in your project and won't care about `CedarJavaFFI`.
 
 ## Security

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -637,6 +637,7 @@ mod interface_tests {
     mod policy_tests {
         use super::*;
 
+        #[track_caller]
         fn policy_effect_test_util(env: &mut JNIEnv, policy: &str, expected_effect: &str) {
             let policy_string = env.new_string(policy).unwrap();
             let effect_result = policy_effect_jni_internal(env, policy_string).unwrap();

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -631,7 +631,7 @@ mod interface_tests {
     use jni::JavaVM;
     use std::sync::LazyLock;
 
-    // Static JVM to be used by all the tests. LazyLock for lazy thread-safe lazy initialization
+    // Static JVM to be used by all the tests. LazyLock for thread-safe lazy initialization
     static JVM: LazyLock<JavaVM> = LazyLock::new(|| create_jvm().unwrap());
 
     mod policy_tests {

--- a/CedarJavaFFI/src/jvm_test_utils.rs
+++ b/CedarJavaFFI/src/jvm_test_utils.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![cfg(test)]
+
+use jni::{InitArgsBuilder, JavaVM};
+
+/// Creates a new Java Virtual Machine (JVM) instance with basic configuration for tests
+///
+/// # Returns
+/// * `Result<JavaVM, jni::errors::StartJvmError>` - A Result containing either:
+///   * `JavaVM` - The successfully created JVM instance
+///   * `StartJvmError` - Error that occurred during JVM creation
+///
+pub(crate) fn create_jvm() -> Result<JavaVM, jni::errors::StartJvmError> {
+    let jvm_args = InitArgsBuilder::new()
+        .option("-Xcheck:jni")
+        .build()
+        .unwrap();
+
+    let jvm = JavaVM::new(jvm_args)?;
+    Ok(jvm)
+}

--- a/CedarJavaFFI/src/lib.rs
+++ b/CedarJavaFFI/src/lib.rs
@@ -19,6 +19,7 @@ mod answer;
 mod interface;
 mod jlist;
 mod jset;
+mod jvm_test_utils;
 mod objects;
 mod tests;
 mod utils;


### PR DESCRIPTION
# Description
- Currently only `fn callCedar` has direct tests in CedarJavaFFI, while other interface methods are tested indirectly via CedarJava. This leads to test coverage failures in CedarJavaFFI for some build systems
- Testing interface methods requires running a JVM instance from Rust
- This PR adds:
  - A utility method to create a single immutable JVM instance for use across parallel tests
  - An example test demonstrating usage of the shared JVM instance