### PR TITLE
Resolves #257

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationSuccessResponse.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/AuthorizationSuccessResponse.java
@@ -116,6 +116,19 @@ public final class AuthorizationSuccessResponse {
             this.policyId = policyId;
             this.error = error;
         }
+
+        public String getPolicyId() {
+            return this.policyId;
+        }
+
+        public DetailedError getError() {
+            return this.error;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("AuthorizationError{policyId=%s, error=%s}", policyId, error);   
+        }
     }
 
     /** Result of request evaluation. */

--- a/CedarJava/src/main/java/com/cedarpolicy/model/DetailedError.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/DetailedError.java
@@ -105,5 +105,18 @@ public class DetailedError {
             this.start = start;
             this.end = end;
         }
+
+        @Override
+        public String toString() {
+            return String.format("SourceLabel{label=\"%s\", start=%s, end=%s}", label.orElse(""), start, end);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "DetailedError{message=\"%s\", help=\"%s\", code=\"%s\", url=\"%s\", severity=%s, sourcelocations=%s, related=%s}",
+                message, help.orElse(""), code.orElse(""), url.orElse(""), severity.map(Severity::toString).orElse(""),
+                sourceLocations, related);
     }
 }


### PR DESCRIPTION
Resolves #257

## Description of changes:
1. Creates public getter methods for `AuthorizationError`
2. Overrides `.toString()` for `AuthorizationError`, `DetailedError`, and `SourceLabel`.

**Example:**
```java
Set<String> reasons = new HashSet<>();
reasons.add("p1");

List<SourceLabel> sourceLabel = List.of(new SourceLabel(Optional.of("sourceLabel"), 0, 10));

final Diagnostics diagnostics = new Diagnostics(new HashSet<>(reasons),
        List.of(new AuthorizationError("policyError1",
                new DetailedError("message", Optional.of("dummyHelp"), 
                Optional.of("dummyCode"),
                Optional.of("dummyUrl"), 
                Optional.of(Severity.Error), 
                Optional.of(sourceLabel),
                Optional.empty()))));

final AuthorizationSuccessResponse authorizationSuccessResponse = new AuthorizationSuccessResponse(
        Decision.Deny, diagnostics);
        
System.out.println(authorizationSuccessResponse)
```
**Output**
```
Deny, reason [p1], 
errors [AuthorizationError{policyId=policyError1, error=DetailedError{message="message", help="dummyHelp", code="dummyCode", url="dummyUrl", severity=Error, sourcelocations=[SourceLabel{label="sourceLabel", start=0, end=10}], related=[]}}
```