### PR TITLE
Adds annotation support for Policy

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -129,17 +129,26 @@ public class Policy {
 
     private void ensureAnnotationsLoaded() throws InternalException {
         if (annotations == null) {
-            this.annotations = getPolicyAnnotationsJni(this.policySrc);
+            try{
+                this.annotations = getPolicyAnnotationsJni(this.policySrc);
+            } catch (InternalException e) {
+                if (e.getMessage().contains("expected a static policy")) {
+                    this.annotations = getTemplateAnnotationsJni(this.policySrc);
+                }
+                else {
+                    throw e;
+                }
+            }
+            
         }
     }
 
     private static native String parsePolicyJni(String policyStr) throws InternalException, NullPointerException;
-    private static native String parsePolicyTemplateJni(String policyTemplateStr)
-            throws InternalException, NullPointerException;
-
+    private static native String parsePolicyTemplateJni(String policyTemplateStr) throws InternalException, NullPointerException;
     private native String toJsonJni(String policyStr) throws InternalException, NullPointerException;
     private static native String fromJsonJni(String policyJsonStr) throws InternalException, NullPointerException;
     private native String policyEffectJni(String policyStr) throws InternalException, NullPointerException;
     private native String templateEffectJni(String policyStr) throws InternalException, NullPointerException;
     private static native Map<String, String> getPolicyAnnotationsJni(String policyStr) throws InternalException;
+    private static native Map<String, String> getTemplateAnnotationsJni(String policyStr) throws InternalException;
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/Policy.java
@@ -23,7 +23,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.cedarpolicy.model.Effect;
 
 import java.util.concurrent.atomic.AtomicInteger;
-
+import java.util.HashMap;
+import java.util.Map;
 
 /** Policies in the Cedar language. */
 public class Policy {
@@ -36,6 +37,8 @@ public class Policy {
     public final String policySrc;
     /** Policy ID. */
     public final String policyID;
+    /** Annotations */
+    private Map<String, String> annotations;
 
     /**
      * Creates a Cedar policy object.
@@ -119,6 +122,17 @@ public class Policy {
         return new Policy(templateText, null);
     }
 
+    public Map<String, String> getAnnotations() throws InternalException {
+        ensureAnnotationsLoaded();
+        return new HashMap<>(this.annotations);
+    }
+
+    private void ensureAnnotationsLoaded() throws InternalException {
+        if (annotations == null) {
+            this.annotations = getPolicyAnnotationsJni(this.policySrc);
+        }
+    }
+
     private static native String parsePolicyJni(String policyStr) throws InternalException, NullPointerException;
     private static native String parsePolicyTemplateJni(String policyTemplateStr)
             throws InternalException, NullPointerException;
@@ -127,4 +141,5 @@ public class Policy {
     private static native String fromJsonJni(String policyJsonStr) throws InternalException, NullPointerException;
     private native String policyEffectJni(String policyStr) throws InternalException, NullPointerException;
     private native String templateEffectJni(String policyStr) throws InternalException, NullPointerException;
+    private static native Map<String, String> getPolicyAnnotationsJni(String policyStr) throws InternalException;
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java
@@ -19,14 +19,17 @@ package com.cedarpolicy;
 import com.cedarpolicy.model.exception.InternalException;
 import com.cedarpolicy.model.policy.Policy;
 import com.cedarpolicy.model.Effect;
-import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Map;
+import java.util.HashMap;
 
 public class PolicyTests {
     @Test
@@ -139,5 +142,89 @@ public class PolicyTests {
         Policy forbidTemplate = new Policy("forbid(principal == ?principal, action, resource == ?resource);", null);
         assertEquals(forbidTemplate.effect(), Effect.FORBID);
 
+    }
+
+    @Test
+    public void givenStaticPolicyGetAnnotationsReturns() throws InternalException {
+        Policy staticPolicy = Policy.parseStaticPolicy("""
+            @id("policyID1")
+            @annotation("myAnnotation")
+            @emptyAnnotation
+            permit(principal, action, resource);
+            """);
+
+        Map<String, String> expectedMap = new HashMap<>();
+        expectedMap.put("id", "policyID1");
+        expectedMap.put("annotation", "myAnnotation");
+        expectedMap.put("emptyAnnotation", "");
+
+        assertEquals(staticPolicy.getAnnotations(), expectedMap);
+
+        Policy staticPolicyNoAnnotations = Policy.parseStaticPolicy("""
+            permit(principal, action, resource);
+            """);
+
+        assertEquals(staticPolicyNoAnnotations.getAnnotations(), new HashMap<>());
+    }
+
+    @Test
+    public void givenStaticPolicyGetAnnotationReturns() throws InternalException {
+        Policy staticPolicy = Policy.parseStaticPolicy("""
+            @id("policyID1")
+            @annotation("myAnnotation")
+            @emptyAnnotation
+            permit(principal, action, resource);
+            """);
+
+        assertEquals(staticPolicy.getAnnotation("annotation"), "myAnnotation");
+        assertEquals(staticPolicy.getAnnotation("emptyAnnotation"), "");
+
+        Policy staticPolicyNoAnnotations = Policy.parseStaticPolicy("""
+            permit(principal, action, resource);
+            """);
+
+        assertEquals(staticPolicyNoAnnotations.getAnnotation("invalidAnnotation"), null);
+    }
+
+    @Test
+    public void givenTemplatePolicyGetAnnotationsReturns() throws InternalException {
+        Policy templatePolicy = Policy.parsePolicyTemplate("""
+            @id("policyID1")
+            @annotation("myAnnotation")
+            @emptyAnnotation
+            permit(principal == ?principal, action, resource);
+            """);
+
+        Map<String, String> expectedMap = new HashMap<>();
+        expectedMap.put("id", "policyID1");
+        expectedMap.put("annotation", "myAnnotation");
+        expectedMap.put("emptyAnnotation", "");
+
+        assertEquals(templatePolicy.getAnnotations(), expectedMap);
+
+        Policy templatePolicyNoAnnotations = Policy.parsePolicyTemplate("""
+            permit(principal == ?principal, action, resource);
+            """);
+
+        assertEquals(templatePolicyNoAnnotations.getAnnotations(), new HashMap<>());
+    }
+
+    @Test
+    public void givenTemplatePolicyGetAnnotationReturns() throws InternalException {
+        Policy templatePolicy = Policy.parsePolicyTemplate("""
+            @id("policyID1")
+            @annotation("myAnnotation")
+            @emptyAnnotation
+            permit(principal == ?principal, action, resource);
+            """);
+
+        assertEquals(templatePolicy.getAnnotation("annotation"), "myAnnotation");
+        assertEquals(templatePolicy.getAnnotation("emptyAnnotation"), "");
+
+        Policy templatePolicyNoAnnotations = Policy.parsePolicyTemplate("""
+            permit(principal == ?principal, action, resource);
+            """);
+
+        assertEquals(templatePolicyNoAnnotations.getAnnotation("invalidAnnotation"), null);
     }
 }

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -705,7 +705,7 @@ fn policies_str_to_pretty_internal<'a>(
 }
 
 #[cfg(test)]
-mod interface_tests {
+mod jvm_based_tests {
     use super::*;
     use crate::jvm_test_utils::*;
     use jni::JavaVM;
@@ -731,6 +731,143 @@ mod interface_tests {
             let mut env = JVM.attach_current_thread().unwrap();
             policy_effect_test_util(&mut env, "permit(principal,action,resource);", "permit");
             policy_effect_test_util(&mut env, "forbid(principal,action,resource);", "forbid");
+        }
+
+        fn assert_id_annotation_eq(
+            env: &mut JNIEnv,
+            annotations: &JObject,
+            annotation_key: &str,
+            expected_annotation_value: &str,
+        ) {
+            let annotation_key_jstr = env.new_string(annotation_key).unwrap();
+            let actual_annotation_value_obj = env
+                .call_method(
+                    annotations,
+                    "get",
+                    "(Ljava/lang/Object;)Ljava/lang/Object;",
+                    &[JValueGen::Object(annotation_key_jstr.as_ref())],
+                )
+                .unwrap()
+                .l()
+                .unwrap();
+
+            let actual_annotation_value_jstr =
+                JString::cast(env, actual_annotation_value_obj).unwrap();
+            let actual_annotation_value_str =
+                String::from(env.get_string(&actual_annotation_value_jstr).unwrap());
+
+            assert_eq!(
+                actual_annotation_value_str, expected_annotation_value,
+                "Returned annotation value should match the annotation in the policy."
+            )
+        }
+
+        #[test]
+        fn static_policy_annotations_tests() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let policy_string = env
+                .new_string("@id(\"policyID1\") @myAnnotationKey(\"myAnnotatedValue\") permit(principal,action,resource);")
+                .unwrap();
+            let annotations = get_policy_annotations_internal(&mut env, policy_string)
+                .unwrap()
+                .l()
+                .unwrap();
+
+            assert_id_annotation_eq(&mut env, &annotations, "id", "policyID1");
+            assert_id_annotation_eq(
+                &mut env,
+                &annotations,
+                "myAnnotationKey",
+                "myAnnotatedValue",
+            );
+        }
+
+        #[test]
+        fn template_policy_annotations_tests() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let policy_string = env
+                .new_string("@id(\"policyID1\") @myAnnotationKey(\"myAnnotatedValue\") permit(principal==?principal,action,resource);")
+                .unwrap();
+            let annotations = get_template_annotations_internal(&mut env, policy_string)
+                .unwrap()
+                .l()
+                .unwrap();
+
+            assert_id_annotation_eq(&mut env, &annotations, "id", "policyID1");
+            assert_id_annotation_eq(
+                &mut env,
+                &annotations,
+                "myAnnotationKey",
+                "myAnnotatedValue",
+            );
+        }
+    }
+
+    mod map_tests {
+        use super::*;
+
+        #[test]
+        fn map_new_tests() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let java_hash_map = Map::<JString, JString>::new(&mut env);
+
+            assert!(java_hash_map.is_ok(), "Map creation should succeed");
+
+            assert!(
+                env.is_instance_of(java_hash_map.unwrap().into_inner(), "java/util/HashMap")
+                    .unwrap(),
+                "Object should be a HashMap instance."
+            );
+        }
+
+        #[test]
+        fn map_put_tests() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let mut java_hash_map = Map::<JString, JString>::new(&mut env).unwrap();
+
+            let key = env.new_string("test_key").unwrap();
+            let value = env.new_string("test_value").unwrap();
+
+            let result = java_hash_map.put(&mut env, key, value);
+
+            assert!(result.is_ok(), "Map put should succeed.");
+
+            let new_key = env.new_string("test_key").unwrap();
+            let new_value = env.new_string("updated_value").unwrap();
+
+            let update_result = java_hash_map.put(&mut env, new_key, new_value);
+
+            assert!(result.is_ok(), "Map put should succeed.");
+
+            let update_result_jstr = JString::cast(&mut env, update_result.unwrap()).unwrap();
+            let update_result_str = String::from(env.get_string(&update_result_jstr).unwrap());
+
+            assert_eq!(
+                update_result_str, "test_value",
+                "Value returned from map update should match the original value of test_key."
+            )
+        }
+
+        #[test]
+        fn map_get_tests() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let mut java_hash_map = Map::<JString, JString>::new(&mut env).unwrap();
+
+            let key = env.new_string("test_key").unwrap();
+            let value = env.new_string("test_value").unwrap();
+
+            let _ = java_hash_map.put(&mut env, key, value);
+
+            let retrieval_key = env.new_string("test_key").unwrap();
+            let retrieved_value = java_hash_map.get(&mut env, retrieval_key).unwrap();
+
+            let retrieved_value_jstr = JString::cast(&mut env, retrieved_value).unwrap();
+            let retrieved_value_str = String::from(env.get_string(&retrieved_value_jstr).unwrap());
+
+            assert_eq!(
+                retrieved_value_str, "test_value",
+                "Retrieved value should be equal to the inserted value."
+            )
         }
     }
 }

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -381,12 +381,7 @@ fn create_java_map_from_annotations<'a, 'b>(
         map.put(env, key, value).unwrap();
     }
 
-    env.new_object(
-        "java/util/HashMap",
-        "(Ljava/util/Map;)V",
-        &[JValueGen::Object(map.as_ref())],
-    )
-    .expect("Failed to create annotation HashMap Object")
+    map.into_inner()
 }
 
 #[jni_fn("com.cedarpolicy.model.policy.Policy")]

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -733,6 +733,7 @@ mod jvm_based_tests {
             policy_effect_test_util(&mut env, "forbid(principal,action,resource);", "forbid");
         }
 
+        #[track_caller]
         fn assert_id_annotation_eq(
             env: &mut JNIEnv,
             annotations: &JObject,

--- a/CedarJavaFFI/src/jmap.rs
+++ b/CedarJavaFFI/src/jmap.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::marker::PhantomData;
+
+use crate::{objects::Object, utils::Result};
+use jni::{
+    objects::{JObject, JValueGen},
+    JNIEnv,
+};
+
+/// Typed wrapper for Java maps
+/// (java.util.Map)
+#[derive(Debug)]
+pub struct Map<'a, T, U> {
+    /// Underlying Java object
+    obj: JObject<'a>,
+    /// ZST for tracking key type info
+    key_marker: PhantomData<T>,
+    /// ZST for tracking value type info
+    value_marker: PhantomData<U>,
+}
+
+impl<'a, T: Object<'a>, U: Object<'a>> Map<'a, T, U> {
+    /// Construct an empty hash map, which will serve as a map
+    pub fn new(env: &mut JNIEnv<'a>) -> Result<Self> {
+        let obj = env.new_object("java/util/HashMap", "()V", &[])?;
+
+        Ok(Self {
+            obj,
+            key_marker: PhantomData,
+            value_marker: PhantomData,
+        })
+    }
+
+    /// Get a value mapped to a key
+    pub fn get(&mut self, env: &mut JNIEnv<'a>, k: T) -> Result<JObject<'a>> {
+        let key = JValueGen::Object(k.as_ref());
+        let value = env
+            .call_method(
+                &self.obj,
+                "get",
+                "(Ljava/lang/Object;)Ljava/lang/Object;",
+                &[key],
+            )?
+            .l()?;
+        Ok(value)
+    }
+
+    /// Put a key-value pair into the map
+    pub fn put(&mut self, env: &mut JNIEnv<'a>, k: T, v: U) -> Result<JObject<'a>> {
+        let key = JValueGen::Object(k.as_ref());
+        let value = JValueGen::Object(v.as_ref());
+        let value = env
+            .call_method(
+                &self.obj,
+                "put",
+                "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                &[key, value],
+            )?
+            .l()?;
+        Ok(value)
+    }
+}
+
+impl<'a, T, U> AsRef<JObject<'a>> for Map<'a, T, U> {
+    fn as_ref(&self) -> &JObject<'a> {
+        &self.obj
+    }
+}

--- a/CedarJavaFFI/src/jmap.rs
+++ b/CedarJavaFFI/src/jmap.rs
@@ -74,6 +74,7 @@ impl<'a, T: Object<'a>, U: Object<'a>> Map<'a, T, U> {
             .l()?;
         Ok(value)
     }
+
     /// Consumes the Map and returns the underlying JObject
     pub fn into_inner(self) -> JObject<'a> {
         self.obj

--- a/CedarJavaFFI/src/jmap.rs
+++ b/CedarJavaFFI/src/jmap.rs
@@ -74,6 +74,10 @@ impl<'a, T: Object<'a>, U: Object<'a>> Map<'a, T, U> {
             .l()?;
         Ok(value)
     }
+    /// Consumes the Map and returns the underlying JObject
+    pub fn into_inner(self) -> JObject<'a> {
+        self.obj
+    }
 }
 
 impl<'a, T, U> AsRef<JObject<'a>> for Map<'a, T, U> {

--- a/CedarJavaFFI/src/lib.rs
+++ b/CedarJavaFFI/src/lib.rs
@@ -18,6 +18,7 @@
 mod answer;
 mod interface;
 mod jlist;
+mod jmap;
 mod jset;
 mod jvm_test_utils;
 mod objects;


### PR DESCRIPTION
## Description
This PR implements annotation getters for the `Policy` class, providing access to both static policy and template policy annotations.

## Key Changes
- Implements a Java HashMap in `CedarJavaFFI` for annotation management and JNI communication
- Adds annotation access methods to `Policy` class:
  - `getAnnotation(String key)`
  - `getAnnotations()`
- Implements lazy loading pattern for annotations:
  - Annotations initialize via JNI only on first getter call
  - Subsequent calls utilize cached annotations
- Adds test coverage for:
  - New FFI methods
  - `CedarJavaFFI` HashMap implementation
  - `Policy` annotation getters

## Implementation Details
1. Handling Static Policies and Templates
   - Uses try-catch approach to attempt static policy annotation retrieval first
   - Falls back to template annotation retrieval on failure (`errorMessage.contains("expected a static policy")`)
   - Current implementation relies on error message parsing (precedent in [PolicyTests](https://github.com/cedar-policy/cedar-java/blob/3421046fbb842879cb3c5244545621cf900e4a96/CedarJava/src/test/java/com/cedarpolicy/PolicyTests.java#L92)). Limited by information exposed by cedar-policy's `ParseError` (tracking in [#979](https://github.com/cedar-policy/cedar/issues/979))
   - Alternative: Completely consume `ParseError` for static policies (as in PR #275)
   - Temporary workaround until `Policy` and `Template` class separation

2. Lazy Loading Strategy
   - Loads annotations on-demand instead of in `Policy` constructor to preserve backward compatibility by avoiding addition of `InternalException` in constructor signature.