### PR TITLE
Refines documentation

### DIFF
--- a/CedarJava/CHANGELOG.md
+++ b/CedarJava/CHANGELOG.md
@@ -7,7 +7,7 @@
   * `com.cedarpolicy.model.entity.Entities` - Entity collection management (will replace `Set<Entity>`) [#293](https://github.com/cedar-policy/cedar-java/pull/293)
 * Enhanced `AuthorizationError` with public getters and `.toString()` method [#294](https://github.com/cedar-policy/cedar-java/pull/294)
 * Added JSON parsing support for `Entity` [#292](https://github.com/cedar-policy/cedar-java/pull/292)
-* Implemented additional constructors for improved instantiation options for `Entity` [#288](https://github.com/cedar-policy/cedar-java/pull/288/files)
+* Implemented additional constructors for improved instantiation options for `Entity` [#288](https://github.com/cedar-policy/cedar-java/pull/288)
 * Added support for policy annotations [#296](https://github.com/cedar-policy/cedar-java/pull/296)
 
 ### Future Deprecation Notice
@@ -15,7 +15,7 @@
   * `Map<String,Value>` for context will be replaced by `com.cedarpolicy.model.Context`
   * `Set<Entity>` for entities will be replaced by `com.cedarpolicy.model.entity.Entities`
 
-## 3.x
+## 3.0
 
 * Reworked interface of `com.cedarpolicy.value.EntityUID` to support namespaces
 * Modified `com.cedarpolicy.model.AuthorizationRequest` to use `com.cedarpolicy.value.EntityUID` instead of Strings

--- a/CedarJava/CHANGELOG.md
+++ b/CedarJava/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 ## Unreleased
+### Added
+* Introduced new model classes for improved type safety and functionality:
+  * `com.cedarpolicy.model.Context` - Policy context representation (will replace `Map<String,Value>`) [#286](https://github.com/cedar-policy/cedar-java/pull/286)
+  * `com.cedarpolicy.model.entity.Entities` - Entity collection management (will replace `Set<Entity>`) [#293](https://github.com/cedar-policy/cedar-java/pull/293)
+* Enhanced `AuthorizationError` with public getters and `.toString()` method [#294](https://github.com/cedar-policy/cedar-java/pull/294)
+* Added JSON parsing support for `Entity` [#292](https://github.com/cedar-policy/cedar-java/pull/292)
+* Implemented additional constructors for improved instantiation options for `Entity` [#288](https://github.com/cedar-policy/cedar-java/pull/288/files)
+* Added support for policy annotations [#296](https://github.com/cedar-policy/cedar-java/pull/296)
+
+### Future Deprecation Notice
+* Authorization request parameters will be updated in a future release:
+  * `Map<String,Value>` for context will be replaced by `com.cedarpolicy.model.Context`
+  * `Set<Entity>` for entities will be replaced by `com.cedarpolicy.model.entity.Entities`
+
+## 3.x
 
 * Reworked interface of `com.cedarpolicy.value.EntityUID` to support namespaces
 * Modified `com.cedarpolicy.model.AuthorizationRequest` to use `com.cedarpolicy.value.EntityUID` instead of Strings

--- a/CedarJava/CHANGELOG.md
+++ b/CedarJava/CHANGELOG.md
@@ -1,17 +1,17 @@
 # Changelog
 
-## Unreleased
+## 4.3
 ### Added
 * Introduced new model classes for improved type safety and functionality:
   * `com.cedarpolicy.model.Context` - Policy context representation (will replace `Map<String,Value>`) [#286](https://github.com/cedar-policy/cedar-java/pull/286)
   * `com.cedarpolicy.model.entity.Entities` - Entity collection management (will replace `Set<Entity>`) [#293](https://github.com/cedar-policy/cedar-java/pull/293)
 * Enhanced `AuthorizationError` with public getters and `.toString()` method [#294](https://github.com/cedar-policy/cedar-java/pull/294)
 * Added JSON parsing support for `Entity` [#292](https://github.com/cedar-policy/cedar-java/pull/292)
-* Implemented additional constructors for improved instantiation options for `Entity` [#288](https://github.com/cedar-policy/cedar-java/pull/288)
+* Implemented additional constructors to improve instantiation options for `Entity` [#288](https://github.com/cedar-policy/cedar-java/pull/288)
 * Added support for policy annotations [#296](https://github.com/cedar-policy/cedar-java/pull/296)
 
-### Future Deprecation Notice
-* Authorization request parameters will be updated in a future release:
+### Planned Improvements
+* The following authorization parameters will be updated in a future release:
   * `Map<String,Value>` for context will be replaced by `com.cedarpolicy.model.Context`
   * `Set<Entity>` for entities will be replaced by `com.cedarpolicy.model.entity.Entities`
 

--- a/CedarJava/CHANGELOG.md
+++ b/CedarJava/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.3
+## Unreleased
 ### Added
 * Introduced new model classes for improved type safety and functionality:
   * `com.cedarpolicy.model.Context` - Policy context representation (will replace `Map<String,Value>`) [#286](https://github.com/cedar-policy/cedar-java/pull/286)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Explore our sample applications in [cedar-examples](https://github.com/cedar-pol
 * [**cedar-java-partial-evaluation**](https://github.com/cedar-policy/cedar-examples/tree/main/cedar-java-partial-evaluation): Illustrates partial evaluation capabilities in Cedar-Java
 
 ## Changelog
-For a list of changes and version updates, see [CHANGELOG.md](https://github.com/cedar-policy/cedar-java/tree/main/CedarJava).
+For a list of changes and version updates, see [CHANGELOG.md](CedarJava/CHANGELOG.md).
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cedar-java
+dddd# cedar-java
 ![Cedar Logo](https://github.com/cedar-policy/cedar/blob/main/logo.svg)  
 
 This repository contains the source code for a Java package `CedarJava` that supports using the [Cedar](https://www.cedarpolicy.com) policy language. It also contains source code for a Rust crate `CedarJavaFFI` that enables calling Cedar library functions (written in Rust) from Java.

--- a/README.md
+++ b/README.md
@@ -38,20 +38,19 @@ Here is a small snippet on how to perform `isAuthorized()` call using `CedarJava
 ```java
 package com.mypackage;
 
-import com.cedarpolicy.model.policy.PolicySet;
-import com.cedarpolicy.value.EntityUID;
 import com.cedarpolicy.AuthorizationEngine;
 import com.cedarpolicy.BasicAuthorizationEngine;
-import com.cedarpolicy.model.entity.Entity;
 import com.cedarpolicy.model.AuthorizationRequest;
+import com.cedarpolicy.model.AuthorizationResponse;
 import com.cedarpolicy.model.Context;
 import com.cedarpolicy.model.entity.Entities;
-import com.cedarpolicy.model.AuthorizationResponse;
+import com.cedarpolicy.model.entity.Entity;
+import com.cedarpolicy.model.policy.PolicySet;
+import com.cedarpolicy.value.EntityUID;
 
 public class SimpleAuthorization {
     public static void main(String[] args) throws Exception {
 
-        System.out.println("HelloWorld");
         // Build entities
         Entity principal = new Entity(EntityUID.parse("User::\"Alice\"").get());
         Entity action = new Entity(EntityUID.parse("Action::\"view\"").get());
@@ -77,7 +76,7 @@ public class SimpleAuthorization {
         Entities entities = new Entities();
         Context context = new Context();
         AuthorizationRequest request  = new AuthorizationRequest(principal, action, resource, context);
-        AuthorizationResponse authorizationResponse = ae.isAuthorized(request,policySet,entities);
+        AuthorizationResponse authorizationResponse = ae.isAuthorized(request, policySet, entities);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-dddd# cedar-java
+# cedar-java
 ![Cedar Logo](https://github.com/cedar-policy/cedar/blob/main/logo.svg)  
 
 This repository contains the source code for a Java package `CedarJava` that supports using the [Cedar](https://www.cedarpolicy.com) policy language. It also contains source code for a Rust crate `CedarJavaFFI` that enables calling Cedar library functions (written in Rust) from Java.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,100 @@
 # cedar-java
+![Cedar Logo](https://github.com/cedar-policy/cedar/blob/main/logo.svg)  
 
-This repository contains the source code for a Java package `CedarJava` that supports using the [Cedar](https://www.cedarpolicy.com) policy language.
-It also contains source code for a Rust crate `CedarJavaFFI` that enables calling Cedar library functions (written in Rust) from Java.
+This repository contains the source code for a Java package `CedarJava` that supports using the [Cedar](https://www.cedarpolicy.com) policy language. It also contains source code for a Rust crate `CedarJavaFFI` that enables calling Cedar library functions (written in Rust) from Java.
+
+Cedar is a language for writing and enforcing authorization policies in your applications. Using Cedar, you can write policies that specify your applications' fine-grained permissions. Your applications then authorize access requests by calling Cedar's authorization engine. Because Cedar policies are separate from application code, they can be independently authored, updated, analyzed, and audited. You can use Cedar's validator to check that Cedar policies are consistent with a declared schema which defines your application's authorization model.
 
 
 ## Getting Started
 
-The [CedarJavaFFI](https://github.com/cedar-policy/cedar-java/blob/main/CedarJavaFFI/README.md) and [CedarJava](https://github.com/cedar-policy/cedar-java/blob/main/CedarJava/README.md) directories contain detailed instructions on building individual modules.
+### Import `CedarJava` to your application
+#### Maven Package
+CedarJava is available as a maven package. You can add `CedarJava` as a dependency to your build file.  
 
-The `CedarJava` module uses Gradle to build both modules and run integration tests. The following commands provide general usage for getting started.
+Example (Gradle): 
+```
+dependencies{
+    implementation 'com.cedarpolicy:cedar-java:4.2.3:uber'
+}
+```
+We highly recommend using the `*-uber.jar` as it also contains the shared library from `CedarJavaFFI`.
+
+See [https://central.sonatype.com/artifact/com.cedarpolicy/cedar-java](https://central.sonatype.com/artifact/com.cedarpolicy/cedar-java) for more details.  
+
+#### Build from Source
+
+The [CedarJavaFFI](https://github.com/cedar-policy/cedar-java/blob/main/CedarJavaFFI/README.md) and [CedarJava](https://github.com/cedar-policy/cedar-java/blob/main/CedarJava/README.md) directories contain detailed instructions on building the individual modules.
+
+The `CedarJava` module uses Gradle to build both modules and run integration tests. It stores the shared library from `CedarJavaFFI` in the `-uber.jar`. The following commands provide general usage for getting started.
 
 ```shell
 cd CedarJava
 ./gradlew build
 ```
 
+### Perform an Authorization Request
+Here is a small snippet on how to perform `isAuthorized()` call using `CedarJava`
+```java
+package com.mypackage;
+
+import com.cedarpolicy.model.policy.PolicySet;
+import com.cedarpolicy.value.EntityUID;
+import com.cedarpolicy.AuthorizationEngine;
+import com.cedarpolicy.BasicAuthorizationEngine;
+import com.cedarpolicy.model.entity.Entity;
+import com.cedarpolicy.model.AuthorizationRequest;
+import com.cedarpolicy.model.Context;
+import com.cedarpolicy.model.entity.Entities;
+import com.cedarpolicy.model.AuthorizationResponse;
+
+public class SimpleAuthorization {
+    public static void main(String[] args) throws Exception {
+
+        System.out.println("HelloWorld");
+        // Build entities
+        Entity principal = new Entity(EntityUID.parse("User::\"Alice\"").get());
+        Entity action = new Entity(EntityUID.parse("Action::\"view\"").get());
+        Entity resource = new Entity(EntityUID.parse("Photo::\"alice_photo\"").get());
+
+        // Build policies
+        PolicySet policySet = PolicySet.parsePolicies("""
+            permit(
+                principal == User::"Alice",
+                action == Action::"view",
+                resource == Photo::"alice_photo"
+            );
+
+            forbid(
+                principal == User::"Alice",
+                action == Action::"view",
+                resource == Photo::"bob_photo"
+            );
+        """);
+        
+        // Authorization request
+        AuthorizationEngine ae = new BasicAuthorizationEngine();
+        Entities entities = new Entities();
+        Context context = new Context();
+        AuthorizationRequest request  = new AuthorizationRequest(principal, action, resource, context);
+        AuthorizationResponse authorizationResponse = ae.isAuthorized(request,policySet,entities);
+    }
+}
+```
+
+## Examples
+Explore our sample applications in [cedar-examples](https://github.com/cedar-policy/cedar-examples/tree/main):
+* [**cedar-java-hello-world**](https://github.com/cedar-policy/cedar-examples/tree/main/cedar-java-hello-world): Demonstrates basic authorization calls using Cedar-Java
+* [**cedar-java-partial-evaluation**](https://github.com/cedar-policy/cedar-examples/tree/main/cedar-java-partial-evaluation): Illustrates partial evaluation capabilities in Cedar-Java
+
+## Changelog
+For a list of changes and version updates, see [CHANGELOG.md](https://github.com/cedar-policy/cedar-java/tree/main/CedarJava).
+
 ## Notes
 
 `CedarJava` requires JDK 17 or later.
 
-Cedar is primarily developed in Rust (in the [cedar](https://github.com/cedar-policy/cedar) repository). As such, `CedarJava` typically lags behind the newest Cedar features. Notably, as of this writing, `CedarJava` does not expose APIs for partial evaluation.
+Cedar is primarily developed in Rust (in the [cedar](https://github.com/cedar-policy/cedar) repository). As such, `CedarJava` typically lags behind the newest Cedar features. 
 
 The `main` branch of this repository is kept up-to-date with the development version of the Rust code (available in the `main` branch of [cedar](https://github.com/cedar-policy/cedar)). Unless you plan to build the Rust code locally, please use the latest `release/x.x.x` branch instead.
 


### PR DESCRIPTION
## Description 
1. Refines README.md
   1. Adds instructions to import `CedarJava` from maven
   2. Adds a mini-example
   3. Adds links to CedarJava examples in `cedar-policy/cedar-examples`
2. Updates CHANGELOG for upcoming release items

