### PR TITLE
Creates Release 4.3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/run_cedar_java_reusable.yml
     with:
-      cedar_policy_ref: "refs/heads/main" # use the latest commit on main
+      cedar_policy_ref: ${{ needs.get-branch-name.outputs.branch_name }} # use the same branch of cedar-policy
       cedar_java_ref: "${{ github.href }}" # use the current PR's commit

--- a/CedarJava/CHANGELOG.md
+++ b/CedarJava/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 4.3.0
 ### Added
 * Introduced new model classes for improved type safety and functionality:
   * `com.cedarpolicy.model.Context` - Policy context representation (will replace `Map<String,Value>`) [#286](https://github.com/cedar-policy/cedar-java/pull/286)

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -258,7 +258,7 @@ publishing {
             from components.java
             groupId = 'com.cedarpolicy'
             artifactId = 'cedar-java'
-            version = '3.1.2'
+            version = '4.3.0'
 
             artifacts {
                 jar

--- a/CedarJavaFFI/Cargo.toml
+++ b/CedarJavaFFI/Cargo.toml
@@ -6,7 +6,7 @@ description = "Java FFI for Cedar (from the cedar-policy crate)."
 edition = "2021"
 
 
-version = "4.0.0"
+version = "4.3.0"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"] }
@@ -30,11 +30,11 @@ jni = { version = "0.21.1", features = ["invocation"] }
 crate_type = ["cdylib"]
 
 [dependencies.cedar-policy]
-version = "4.0.0"
+version = "4.3.3"
 git = "https://github.com/cedar-policy/cedar"
-branch = "main"
+branch = "release/4.3.x"
 
 [dependencies.cedar-policy-formatter]
-version = "4.0.0"
+version = "4.3.3"
 git = "https://github.com/cedar-policy/cedar"
-branch = "main"
+branch = "release/4.3.x"


### PR DESCRIPTION
# Description:
1. Bumps version number in CHANGELOG.MD to **4.3.0**
2. Bumps version number in `CedarJava/build.gradle` to **4.3.0**
3. Updates `CedarJavaFFI/Cargo.toml`:
    1. Bumps version number for `CedarJavaFFI` to **4.3.0**
    2. Bumps `cedar-policy `dependency version to **4.3.3** and sets its branch to `release/4.3.x`
    3. Bumps `cedar-policy-formatter` dependency version to **4.3.3** and sets its branch to `release/4.3.x`
4. Updates Github CI workflow to use `release/4.3.x` branch for `cedar-policy`