### PR TITLE
Adds Zig version validation for publishing task

### DIFF
--- a/CedarJava/CHANGELOG.md
+++ b/CedarJava/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 ### Added
+* Added Zig version validation for publishing artifacts [#306](https://github.com/cedar-policy/cedar-java/pull/306)
+
+## 4.3.0
+### Added
 * Introduced new model classes for improved type safety and functionality:
   * `com.cedarpolicy.model.Context` - Policy context representation (will replace `Map<String,Value>`) [#286](https://github.com/cedar-policy/cedar-java/pull/286)
   * `com.cedarpolicy.model.entity.Entities` - Entity collection management (will replace `Set<Entity>`) [#293](https://github.com/cedar-policy/cedar-java/pull/293)

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -145,7 +145,7 @@ tasks.register('validateZigVersion') {
 }
 
 tasks.register('compileFFI') {
-    dependsOn('installCargoZigbuild', 'validateZigVersion')
+    dependsOn('installCargoZigbuild')
     group 'Build'
     description 'Compiles Foreign Function Interface libraries.'
     exec {
@@ -272,6 +272,7 @@ java {
 /*
  Configures Maven publishing
  */
+publish.dependsOn('validateZigVersion')
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -124,8 +124,28 @@ tasks.register('installCargoZigbuild', Exec) {
     commandLine 'cargo', '+' + RustVersion, 'install', 'cargo-zigbuild@0.19.7'
 }
 
+def ZigVersion = '0.11'
+tasks.register('validateZigVersion') {
+    group = 'Build'
+    description = 'Validates that the correct zig version is installed'
+    
+    doLast {
+        def output = new ByteArrayOutputStream()
+        exec {
+            commandLine 'zig', 'version'
+            standardOutput = output
+        }
+        def version = output.toString().trim()
+        println "Detected Zig version: ${version}"
+        if (!version.startsWith(ZigVersion)) {
+            throw new GradleException("Zig version must be ${ZigVersion} but found: ${version}")        
+        }
+        println "Zig version validation successful"
+    }
+}
+
 tasks.register('compileFFI') {
-    dependsOn('installCargoZigbuild')
+    dependsOn('installCargoZigbuild', 'validateZigVersion')
     group 'Build'
     description 'Compiles Foreign Function Interface libraries.'
     exec {


### PR DESCRIPTION
# Description
This PR adds explicit Zig version (0.11) validation during the publishing process to ensure consistent artifact compatibility. 

**Changes:**
- Adds version check during package publishing
- Does not enforce version check during normal build processes

**Rationale:**
Without version validation, artifacts could be published using different Zig versions, causing compatibility issues. By validating only during publishing, we ensure consistent releases while allowing developers to build from source using their preferred Zig version.

# Testing
1. Running `validateZigVersion` task with incorrect Zig Version:
```
$> gradle validateZigVersion

> Task :validateZigVersion FAILED
Detected Zig version: 0.13.0

[Incubating] Problems report is available at: file:///workplace/chmudit/CedarJavaUpgradePublic/cedar-java/CedarJava/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* Where:
Build file '/workplace/chmudit/CedarJavaUpgradePublic/cedar-java/CedarJava/build.gradle' line: 141

* What went wrong:
Execution failed for task ':validateZigVersion'.
> Zig version must be 0.11 but found: 0.13.0

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.12.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 460ms
```

2. Running `validateZigVersion` task with correct Zig Version:
```
$> gradle validateZigVersion

> Task :validateZigVersion
Detected Zig version: 0.11.0
Zig version validation successful

[Incubating] Problems report is available at: file:///workplace/chmudit/CedarJavaUpgradePublic/cedar-java/CedarJava/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.12.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 483ms
```
3. Publish dry run
```
$> gradle publish --dry-run
info: override toolchain for '/workplace/chmudit/CedarJavaUpgradePublic/cedar-java/CedarJavaFFI' set to '1.83-x86_64-unknown-linux-gnu'
:compileJava SKIPPED
:processResources SKIPPED
:classes SKIPPED
:jar SKIPPED
:javadoc SKIPPED
:javadocJar SKIPPED
:sourcesJar SKIPPED
:generateMetadataFileForMavenJavaPublication SKIPPED
:generatePomFileForMavenJavaPublication SKIPPED
:installRequiredRustVersion SKIPPED
:installCargoZigbuild SKIPPED
:compileFFI SKIPPED
:uberJar SKIPPED
:signMavenJavaPublication SKIPPED
:publishMavenJavaPublicationToMavenRepository SKIPPED
:validateZigVersion SKIPPED
:publish SKIPPED
```