### PR TITLE
updated schema conversion method by moving the schema conversion to t…

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
@@ -16,12 +16,14 @@
 
 package com.cedarpolicy.model.schema;
 
+import java.util.Optional;
+
 import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.model.exception.InternalException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.util.Optional;
 
 /** Represents a schema. */
 public final class Schema {
@@ -106,8 +108,8 @@ public final class Schema {
      * succeeds, return a `Schema`, otherwise raise an exception.
      *
      * @param type The schema format used.
-     * @param str  Schema text to parse.
-     * @throws InternalException    If parsing fails.
+     * @param str Schema text to parse.
+     * @throws InternalException If parsing fails.
      * @throws NullPointerException If the input text is null.
      * @return A {@link Schema} that is guaranteed to be valid.
      */
@@ -122,16 +124,47 @@ public final class Schema {
 
     }
 
+    public String toCedarFormat() throws InternalException {
+        if (type == JsonOrCedar.Cedar && schemaText.isPresent()) {
+            return schemaText.get();
+        } else if (type == JsonOrCedar.Json && schemaJson.isPresent()) {
+            return jsonToCedarJni(schemaJson.get().toString());
+        } else {
+            throw new InternalException("Schema content is missing");
+        }
+    }
+
+    /**
+     * Converts a Cedar format schema to JSON format
+     * 
+     * @return JsonNode representing the schema in JSON format
+     * @throws InternalException       If schema is not in Cedar format
+     * @throws JsonMappingException    If JSON mapping fails
+     * @throws JsonProcessingException If JSON processing fails
+     * @throws NullPointerException    If schema text is null
+     */
+    public JsonNode toJsonFormat()
+            throws InternalException, JsonMappingException, JsonProcessingException, NullPointerException {
+        if (type != JsonOrCedar.Cedar || schemaText.isEmpty()) {
+            throw new InternalException("Schema is not in cedar format");
+        }
+        return OBJECT_MAPPER.readTree(cedarToJsonJni(schemaText.get()));
+
+    }
+  
+
     /** Specifies the schema format used. */
     public enum JsonOrCedar {
         /**
-         * Cedar JSON schema format. See <a href="https://docs.cedarpolicy.com/schema/json-schema.html">
-         *     https://docs.cedarpolicy.com/schema/json-schema.html</a>
+         * Cedar JSON schema format. See
+         * <a href="https://docs.cedarpolicy.com/schema/json-schema.html">
+         * https://docs.cedarpolicy.com/schema/json-schema.html</a>
          */
         Json,
         /**
-         * Cedar schema format. See <a href="https://docs.cedarpolicy.com/schema/human-readable-schema.html">
-         *     https://docs.cedarpolicy.com/schema/human-readable-schema.html</a>
+         * Cedar schema format. See
+         * <a href="https://docs.cedarpolicy.com/schema/human-readable-schema.html">
+         * https://docs.cedarpolicy.com/schema/human-readable-schema.html</a>
          */
         Cedar
     }
@@ -139,4 +172,8 @@ public final class Schema {
     private static native String parseJsonSchemaJni(String schemaJson) throws InternalException, NullPointerException;
 
     private static native String parseCedarSchemaJni(String schemaText) throws InternalException, NullPointerException;
+
+    private static native String jsonToCedarJni(String json) throws InternalException, NullPointerException;
+
+    private static native String cedarToJsonJni(String cedar) throws InternalException, NullPointerException;
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/EntitiesTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntitiesTests.java
@@ -16,24 +16,26 @@
 
 package com.cedarpolicy;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import com.cedarpolicy.value.*;
-import com.cedarpolicy.model.entity.Entity;
-import com.cedarpolicy.model.entity.Entities;
-import static com.cedarpolicy.CedarJson.objectWriter;
-
-import org.skyscreamer.jsonassert.*;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.json.JSONException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.cedarpolicy.CedarJson.objectWriter;
+import com.cedarpolicy.model.entity.Entities;
+import com.cedarpolicy.model.entity.Entity;
+import com.cedarpolicy.value.EntityUID;
+import com.cedarpolicy.value.PrimString;
+import com.cedarpolicy.value.Value;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class EntitiesTests {
     private static final String TEST_RESOURCES_DIR = "src/test/resources/";
@@ -60,7 +62,7 @@ public class EntitiesTests {
     }
 
     @Test
-    public void givenValidJSONStringParseReturns() throws JsonProcessingException {
+    public void givenValidJSONStringParseReturns() throws JsonProcessingException, JSONException {
         String validEntitiesJson = """
                 [
                     {"uid":{"type":"Photo","id":"pic02"},"parents":[{"type":"PhotoParent","id":"picParent"}],
@@ -98,7 +100,7 @@ public class EntitiesTests {
     }
 
     @Test
-    public void givenInvalidJSONStringParseThrows() throws JsonProcessingException {
+    public void givenInvalidJSONStringParseThrows() throws JsonProcessingException, JSONException {
         String invalidEntityJson = """
                 [{"uid":{"type":"Photo","id":"pic01"}},
                 {"uid":{"type":"Photo","id":"pic02"},"parents":[],"attrs":{}}]
@@ -119,7 +121,7 @@ public class EntitiesTests {
     }
 
     @Test
-    public void givenValidJSONFileParseReturns() throws JsonProcessingException, IOException {
+    public void givenValidJSONFileParseReturns() throws JsonProcessingException, IOException, JSONException {
         Entities entities = Entities.parse(Path.of(TEST_RESOURCES_DIR + "valid_entities.json"));
         String actualRepresentation = objectWriter().writeValueAsString(entities);
         String expectedRepresentation = "{\"entities\":[" + "{\"uid\":{\"type\":\"Photo\",\"id\":\"pic02\"},"

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-use cedar_policy::entities_errors::EntitiesError;
 #[cfg(feature = "partial-eval")]
 use cedar_policy::ffi::is_authorized_partial_json_str;
+use cedar_policy::ffi::Schema as FFISchema;
+use cedar_policy::{
+    entities_errors::EntitiesError,
+    ffi::{schema_to_json, schema_to_text, SchemaToJsonAnswer, SchemaToTextAnswer},
+};
+
 use cedar_policy::{
     ffi::{is_authorized_json_str, validate_json_str},
     Entities, EntityUid, Policy, PolicySet, Schema, Template,
@@ -703,18 +707,90 @@ fn policies_str_to_pretty_internal<'a>(
         }
     }
 }
+#[jni_fn("com.cedarpolicy.model.schema.Schema")]
+pub fn jsonToCedarJni<'a>(mut env: JNIEnv<'a>, _: JClass, json_schema: JString<'a>) -> jvalue {
+    match get_cedar_schema_internal(&mut env, json_schema) {
+        Ok(val) => val.as_jni(),
+        Err(e) => jni_failed(&mut env, e.as_ref()),
+    }
+}
+pub fn get_cedar_schema_internal<'a>(
+    env: &mut JNIEnv<'a>,
+    schema_json_jstr: JString<'a>,
+) -> Result<JValueOwned<'a>> {
+    let rust_str = env.get_string(&schema_json_jstr)?;
+    let schema_str = rust_str.to_str()?;
+
+    let schema: FFISchema = serde_json::from_str(schema_str)?;
+    let cedar_format = schema_to_text(schema);
+
+    match cedar_format {
+        SchemaToTextAnswer::Success { text, warnings } => 
+        {
+            let jstr = env.new_string(&text)?;
+            Ok(JValueGen::Object(JObject::from(jstr)).into())
+        },
+        SchemaToTextAnswer::Failure { errors } => {
+            let joined_errors = errors
+                .iter()
+                .map(|e| e.message.clone())
+                .collect::<Vec<_>>()
+                .join("; ");
+            Err(joined_errors.into())
+        }
+    }
+}
+
+#[jni_fn("com.cedarpolicy.model.schema.Schema")]
+pub fn cedarToJsonJni<'a>(mut env: JNIEnv<'a>, _: JClass, cedar_schema: JString<'a>) -> jvalue {
+    match get_json_schema_internal(&mut env, cedar_schema) {
+        Ok(val) => val.as_jni(),
+        Err(e) => jni_failed(&mut env, e.as_ref()),
+    }
+}
+
+pub fn get_json_schema_internal<'a>(
+    env: &mut JNIEnv<'a>, 
+    cedar_schema_jstr: JString<'a>
+) -> Result<JValueOwned<'a>> {
+    let schema_jstr = env.get_string(&cedar_schema_jstr)?;
+    let schema_str = schema_jstr.to_str()?;
+    let cedar_schema_str = FFISchema::Cedar(schema_str.into());
+    let json_format = schema_to_json(cedar_schema_str);
+
+    match json_format {
+        SchemaToJsonAnswer::Success { json, warnings: _ } => {
+            let json_pretty = serde_json::to_string_pretty(&json)?;
+            let jstr = env.new_string(&json_pretty)?;
+            Ok(JValueGen::Object(JObject::from(jstr)).into())
+        }
+        SchemaToJsonAnswer::Failure { errors } => {
+            let joined_errors = errors
+                .iter()
+                .map(|e| e.message.clone())
+                .collect::<Vec<_>>()
+                .join("; ");
+            Err(joined_errors.into())
+        }
+    }
+}                 
+
 
 #[cfg(test)]
-mod jvm_based_tests {
+pub(crate) mod jvm_based_tests {
     use super::*;
     use crate::jvm_test_utils::*;
     use jni::JavaVM;
     use std::sync::LazyLock;
 
+    pub(crate) static JVM: LazyLock<JavaVM> = LazyLock::new(|| create_jvm().unwrap());
     // Static JVM to be used by all the tests. LazyLock for thread-safe lazy initialization
-    static JVM: LazyLock<JavaVM> = LazyLock::new(|| create_jvm().unwrap());
 
     mod policy_tests {
+        use std::result;
+
+        use cedar_policy::Effect;
+
         use super::*;
 
         #[track_caller]
@@ -731,6 +807,17 @@ mod jvm_based_tests {
             let mut env = JVM.attach_current_thread().unwrap();
             policy_effect_test_util(&mut env, "permit(principal,action,resource);", "permit");
             policy_effect_test_util(&mut env, "forbid(principal,action,resource);", "forbid");
+        }
+        #[test]
+        fn policy_effect_jni_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_obj = JObject::null();
+            let result = policy_effect_jni_internal(&mut env, null_obj.into());
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected Java exception due to a null input"
+            );
         }
 
         #[track_caller]
@@ -802,8 +889,328 @@ mod jvm_based_tests {
                 "myAnnotatedValue",
             );
         }
-    }
+        #[test]
+        fn get_template_annotations_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_obj = JObject::null();
+            let result = get_template_annotations_internal(&mut env, null_obj.into());
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected java exception due to a null input"
+            );
+        }
+        #[test]
+        fn parse_policy_internal_success_basic() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let input = r#"permit(principal,action,resource);"#;
+            let policy_jstr = env.new_string(input).unwrap();
 
+            let result = parse_policy_internal(&mut env, policy_jstr);
+            assert!(
+                result.is_ok(),
+                "Expected parse_policy_internal to succeed: {:?}",
+                result
+            );
+
+            let jvalue = result.unwrap();
+            let parsed_jstring = JString::cast(&mut env, jvalue.l().unwrap()).unwrap();
+            let actual_parsed_string = String::from(env.get_string(&parsed_jstring).unwrap());
+            let expected_policy_object = cedar_policy::Policy::from_str(input).unwrap();
+            let expected_canonical_string = expected_policy_object.to_string();
+
+            assert_eq!(
+                actual_parsed_string, expected_canonical_string,
+                "Parsed policy string should match the expected canonical format."
+            );
+        }
+
+        #[test]
+        fn parse_policy_template_internal_invalid_missing_template_slots() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let input = r#"permit(principal == User::"alice", action == Action::"read", resource == Resource::"file");"#;
+            let jstr = env.new_string(input).unwrap();
+
+            let result = parse_policy_template_internal(&mut env, jstr);
+
+            assert!(
+                result.is_err(),
+                "Expected parse_policy_template_internal to fail due to missing template slots"
+            );
+        }
+        #[test]
+        fn get_policy_annotations_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_obj = JObject::null();
+            let result = get_policy_annotations_internal(&mut env, null_obj.into());
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected java exception due to a null input"
+            );
+        }
+        #[test]
+        fn parse_policy_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_str = JString::from(JObject::null());
+            let result = parse_policy_internal(&mut env, null_str);
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected Java exception due to a null input"
+            );
+        }
+        #[test]
+        fn parse_policy_template_valid_test() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let policy_template = r#"permit(principal==?principal,action == Action::"readfile",resource==?resource );"#;
+            let jstr = env.new_string(policy_template).unwrap();
+            let result = parse_policy_template_internal(&mut env, jstr);
+            assert!(result.is_ok());
+
+            let jvalue = result.unwrap();
+            let parsed_jstring = JString::cast(&mut env, jvalue.l().unwrap()).unwrap();
+            let actual_parsed_string = String::from(env.get_string(&parsed_jstring).unwrap());
+            let expected_template_object =
+                cedar_policy::Template::from_str(policy_template).unwrap();
+            let expected_canonical_string = expected_template_object.to_string();
+
+            assert_eq!(
+                actual_parsed_string, expected_canonical_string,
+                "Parsed template string should match the expected canonical format."
+            );
+        }
+
+        #[test]
+        fn parse_policy_template_invalid_test() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let invalid_input = r#"permit(Principa,Action,Resource );"#;
+            let jstr = env.new_string(invalid_input).unwrap();
+            let result = parse_policy_template_internal(&mut env, jstr);
+            assert!(result.is_err(), "Expected to fail for invalid input");
+        }
+        #[test]
+        fn parse_policy_template_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_str = JString::from(JObject::null());
+            let result = parse_policy_template_internal(&mut env, null_str);
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected Java exception due to a null input"
+            );
+        }
+        #[test]
+        fn from_json_test_valid() {
+            let mut env = JVM.attach_current_thread().unwrap();
+
+            let policy_json = r#"
+    {
+        "effect": "permit",
+        "principal": {
+            "op": "==",
+            "entity": { "type": "User", "id": "12UA45" }
+        },
+        "action": {
+            "op": "==",
+            "entity": { "type": "Action", "id": "view" }
+        },
+        "resource": {
+            "op": "in",
+            "entity": { "type": "Folder", "id": "abc" }
+        },
+        "conditions": [
+            {
+                "kind": "when",
+                "body": {
+                    "==": {
+                        "left": {
+                            ".": {
+                                "left": { "Var": "context" },
+                                "attr": "tls_version"
+                            }
+                        },
+                        "right": { "Value": "1.3" }
+                    }
+                }
+            }
+        ]
+    }
+    "#;
+
+            let java_str = env.new_string(policy_json).unwrap();
+            let result = from_json_internal(&mut env, java_str);
+            assert!(
+                result.is_ok(),
+                "Expected from_json parsing to succeed, got: {:?}",
+                result
+            );
+
+            let java_val = result.unwrap();
+            let obj = java_val.l().unwrap();
+            let policy_str: String = env.get_string(&obj.into()).unwrap().into();
+
+            let policy_json_value: serde_json::Value = serde_json::from_str(policy_json).unwrap();
+            let expected_policy = cedar_policy::Policy::from_json(None, policy_json_value).unwrap();
+            let expected_policy_str = expected_policy.to_string();
+
+            assert_eq!(
+                policy_str, expected_policy_str,
+                "Parsed policy string should match the expected Cedar policy format"
+            );
+        }
+        #[test]
+        fn from_json_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_str = JString::from(JObject::null());
+            let result = from_json_internal(&mut env, null_str);
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected Java exception due to a null input"
+            );
+        }
+
+        #[test]
+        fn from_json_invalid() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let invalid_input = r#"
+        {
+            "Effect": "permit",
+            "Principal": {
+                "op": "==",
+                "Entity": { "type": "User", "id": "12UA45" }
+            },
+            "Action": {
+                "op": "==",
+                "entity": { "type": "Action", "id": "view" }
+            },
+            "Resource": {
+                "op": "in",
+                "entity": { "type": "Folder", "id": "abc" }
+            },
+            "Conditions": [
+                {
+                    "kind": "when",
+                    "body": {
+                        "==": {
+                            "left": {
+                                ".": {
+                                    "left": {
+                                        "Var": "context"
+                                    },
+                                    "attr": "tls_version"
+                                }
+                            },
+                            "right": {
+                                "Value": "1.3"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+        "#;
+
+            let java_str = env.new_string(invalid_input).unwrap();
+            let result = from_json_internal(&mut env, java_str);
+            assert!(
+                result.is_err(),
+                "Expected json parsing to fail: {:?}",
+                result
+            );
+        }
+
+        #[test]
+        fn to_json_internal_test() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let input = r#"permit(principal, action, resource);"#;
+            let jstr = env.new_string(input).unwrap();
+            let result = to_json_internal(&mut env, jstr);
+
+            assert!(result.is_ok(), "Expected to_json to succeed");
+
+            let jval = result.unwrap();
+            let obj = jval.l().unwrap();
+            let actual_json_str: String = env.get_string(&obj.into()).unwrap().into();
+
+            let expected_policy = cedar_policy::Policy::from_str(input).unwrap();
+            let expected_json_str =
+                serde_json::to_string(&expected_policy.to_json().unwrap()).unwrap();
+
+            assert_eq!(
+                actual_json_str, expected_json_str,
+                "Generated JSON should match expected policy JSON format"
+            );
+        }
+
+        #[test]
+        fn to_json_internal_invalid() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let invalid_input = r#"Permit(Principal, Resource, Action);"#;
+            let jstr = env.new_string(invalid_input).unwrap();
+
+            let result = from_json_internal(&mut env, jstr);
+            assert!(
+                result.is_err(),
+                "Expected json_internal parsing to fail: {:?}",
+                result
+            );
+        }
+        #[test]
+        fn to_json_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_str = JString::from(JObject::null());
+            let result = to_json_internal(&mut env, null_str);
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected Java exception due to a null input"
+            );
+        }
+        #[test]
+        fn template_effect_jni_internal_permit_test() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let template_policy = r#"permit(principal==?principal,action == Action::"readfile",resource==?resource );"#;
+
+            let jstr = env.new_string(template_policy).unwrap();
+            let result = template_effect_jni_internal(&mut env, jstr);
+            assert!(result.is_ok());
+
+            let jvalue = result.unwrap();
+            let jstring = JString::cast(&mut env, jvalue.l().unwrap()).unwrap();
+            let effect = String::from(env.get_string(&jstring).unwrap());
+            assert_eq!(effect, "permit");
+        }
+
+        #[test]
+        fn template_effect_jni_internal_forbid_test() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let cedar_policy = r#"forbid(principal==?principal,action == Action::"readfile",resource==?resource );"#;
+            let jstr = env.new_string(cedar_policy).unwrap();
+
+            let result = template_effect_jni_internal(&mut env, jstr);
+            assert!(result.is_ok());
+
+            let jvalue = result.unwrap();
+            let jstring = JString::cast(&mut env, jvalue.l().unwrap()).unwrap();
+            let effect = String::from(env.get_string(&jstring).unwrap());
+
+            assert_eq!(effect, "forbid");
+        }
+
+        #[test]
+        fn template_effect_jni_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_obj = JObject::null();
+            let result = template_effect_jni_internal(&mut env, null_obj.into());
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected Java exception due to a null input"
+            );
+        }
+    }
     mod map_tests {
         use super::*;
 
@@ -871,4 +1278,279 @@ mod jvm_based_tests {
             )
         }
     }
+    mod schema_test {
+        use std::result;
+
+        use super::*;
+        use cedar_policy::{EntityId, Schema};
+
+        #[test]
+        fn parse_json_schema_internal_valid_test() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let input = r#"{
+    "schema": {
+        "entityTypes": {
+            "User": {
+                "memberOfTypes": ["Group"]
+            },
+            "Group": {},
+            "File": {}
+        },
+        "actions": {
+            "read": {
+                "appliesTo": {
+                    "principalTypes": ["User"],
+                    "resourceTypes": ["File"]
+                }
+            }
+        }
+    }
+}"#;
+            let jstr = env.new_string(input).unwrap();
+            let result = parse_json_schema_internal(&mut env, jstr);
+            assert!(result.is_ok(), "Expected schema to parse successfully");
+
+            let output = result.unwrap();
+            let jstring_obj = output.l().unwrap();
+            let jstring: jni::objects::JString = JString::from(jstring_obj);
+            let rust_output: String = env.get_string(&jstring).unwrap().into();
+            assert_eq!(rust_output, "success");
+        }
+
+        #[test]
+        fn parse_json_schema_internal_invalid_test() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let invalid_input = r#"{
+    "Schema": {
+        "entityTypes": {
+            "User": {
+                "MemberOfTypes": ["Group"]
+            },
+            "Group": {},
+            "File": {}
+        },
+        "Actions": {
+            "read": {
+                "AppliesTo": {
+                    "principalTypes": ["User"],
+                    "AesourceTypes": ["File"]
+                }
+            }
+        }
+    }
+}
+    "#;
+
+            let jstr = env.new_string(invalid_input).unwrap();
+            let result = parse_json_schema_internal(&mut env, jstr);
+            assert!(
+                result.is_err(),
+                "Expected json_schema_internal parsing to fail: {:?}",
+                result
+            );
+        }
+        #[test]
+        fn parse_json_schema_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_str = JString::from(JObject::null());
+            let result = parse_json_schema_internal(&mut env, null_str);
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected Java exception due to a null input"
+            );
+        }
+        #[test]
+        fn parse_cedar_schema_internal_invalid() {
+            let mut env = JVM.attach_current_thread().unwrap();
+
+            let invalid_input = "Not a valid input";
+            let schema_jstr = env.new_string(invalid_input).unwrap();
+            let result = parse_cedar_schema_internal(&mut env, schema_jstr);
+            assert!(
+                result.is_err(),
+                "Expected parse_cedar_schema_internal to fail"
+            );
+        }
+        #[test]
+        fn parse_cedar_schema_internal_valid() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let input = r#"
+            entity User = {
+                name: String,
+                age?: Long,
+            };
+            entity Photo in Album;
+            entity Album;
+            action view appliesTo {
+                principal : [User],
+                resource: [Album,Photo]
+            };
+            "#;
+
+            let schema_jstr = env.new_string(input).unwrap();
+            let result = parse_cedar_schema_internal(&mut env, schema_jstr);
+
+            assert!(
+                result.is_ok(),
+                "Expected parse_cedar_schema_internal to succeed"
+            );
+
+            let jvalue = result.unwrap();
+            let parsed_jstring = JString::cast(&mut env, jvalue.l().unwrap()).unwrap();
+            let parsed_string = String::from(env.get_string(&parsed_jstring).unwrap());
+            assert_eq!(parsed_string, "success");
+        }
+        #[test]
+        fn parse_cedar_schema_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_str = JString::from(JObject::null());
+            let result = parse_cedar_schema_internal(&mut env, null_str);
+            assert!(result.is_ok(), "Expected error on null input");
+            assert!(
+                env.exception_check().unwrap(),
+                "Expected Java exception due to a null input"
+            );
+        }
+        #[test]
+        fn test_get_template_annotations_internal_invalid_template() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let invalid_template = "invalid template syntax";
+            let jstr = env.new_string(invalid_template).unwrap();
+
+            let result = get_template_annotations_internal(&mut env, jstr);
+            assert!(
+                result.is_err(),
+                "Expected error for invalid template syntax"
+            );
+        }
+    }
+    mod conversion_tests {
+        use super::*;
+        
+        #[test]
+        fn get_cedar_schema_internal_valid() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let json_input = r#"{
+    "schema": {
+        "entityTypes": {
+            "User": {
+                "memberOfTypes": ["Group"]
+            },
+            "Group": {},
+            "File": {}
+        },
+        "actions": {
+            "read": {
+                "appliesTo": {
+                    "principalTypes": ["User"],
+                    "resourceTypes": ["File"]
+                }
+            }
+        }
+    }
+}"#;
+
+            let jstr = env.new_string(json_input).unwrap();
+            let result = get_cedar_schema_internal(&mut env, jstr);
+            assert!(result.is_ok(), "Expected Cedar conversion to succeed");
+            
+            let cedar_jval = result.unwrap();
+            let cedar_jstr = JString::cast(&mut env, cedar_jval.l().unwrap()).unwrap();
+            let cedar_str = String::from(env.get_string(&cedar_jstr).unwrap());
+           
+            assert!(cedar_str.contains("User"), "Expected output to contain 'User'");
+            assert!(cedar_str.contains("Group"), "Expected output to contain 'Group'");
+            assert!(cedar_str.contains("File"), "Expected output to contain 'File'");
+            assert!(cedar_str.contains("read"), "Expected output to contain 'read'");
+        }
+
+        #[test]
+        fn get_cedar_schema_internal_invalid() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let json_input = r#"
+        
+            entity User = {
+                        name: String,
+                        age?: Long,
+                    };
+                    entity Photo in Album;
+                    entity Album;
+                    action view appliesTo {
+                        principal : [User],
+                        resource: [Album,Photo]
+                    };
+            "#;
+
+            let jstr = env.new_string(json_input).unwrap();
+            let result = get_cedar_schema_internal(&mut env, jstr);
+            assert!(
+                result.is_err(),
+                "Expected get_cedar_schema_internal to fail {:?}",
+                result
+            );
+        }
+        
+        #[test]
+        fn get_cedar_schema_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_str = JString::from(JObject::null());
+            let result = get_cedar_schema_internal(&mut env, null_str);
+            assert!(result.is_err(), "Expected error on null input");
+        }
+        
+        #[test]
+        fn get_json_schema_internal_valid() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let cedar_input = r#"
+        entity User = {
+            name: String,
+            age?: Long,
+        };
+        entity Photo in Album;
+        entity Album;
+        action view appliesTo {
+            principal : [User],
+            resource: [Album,Photo]
+        }; 
+    "#;
+
+            let jstr = env.new_string(cedar_input).unwrap();
+            let result = get_json_schema_internal(&mut env, jstr);
+            assert!(result.is_ok(), "Expected JSON conversion to succeed");
+
+            let json_jval = result.unwrap();
+            let json_jstr = JString::cast(&mut env, json_jval.l().unwrap()).unwrap();
+            let json_str = String::from(env.get_string(&json_jstr).unwrap());
+            
+            assert!(json_str.contains("\"entityTypes\""), "Expected output to contain 'entityTypes'");
+            assert!(json_str.contains("\"User\""), "Expected output to contain 'User'");
+            assert!(json_str.contains("\"Album\""), "Expected output to contain 'Album'");
+            assert!(json_str.contains("\"Photo\""), "Expected output to contain 'Photo'");
+            assert!(json_str.contains("\"actions\""), "Expected output to contain 'actions'");
+            assert!(json_str.contains("\"view\""), "Expected output to contain 'view'");
+        }
+        
+        #[test]
+        fn get_json_schema_internal_invalid_input() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let invalid_cedar = "this is not cedar schema";
+            let jstr = env.new_string(invalid_cedar).unwrap();
+
+            let result = get_json_schema_internal(&mut env, jstr);
+            assert!(
+                result.is_err(),
+                "Expected get_json_schema_internal to fail: {:?}",
+                result
+            );
+        }
+        
+        #[test]
+        fn get_json_schema_internal_null() {
+            let mut env = JVM.attach_current_thread().unwrap();
+            let null_str = JString::from(JObject::null());
+            let result = get_json_schema_internal(&mut env, null_str);
+            assert!(result.is_err(), "Expected error on null input");
+        }
+}
 }


### PR DESCRIPTION
I tried to update the branch to not be behind(tried). But I updated the conversion methods on the rust side so that the internal methods are handling the actual schema "conversion" and removed it from the JNI method. I also updated the Java side so that the json returns a JsonNode. as well making it so that the "toCedar" returns a string.


