### PR TITLE
adds schema conversion APIs

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
@@ -130,15 +130,15 @@ public final class Schema {
      * @return String representing the schema in Cedar format
      * @throws InternalException     If conversion from JSON to Cedar format fails
      * @throws IllegalStateException If schema content is missing
-     * @throws NullPointerException  If schema text is null
+     * @throws NullPointerException
      */
-    public String toCedarFormat() throws InternalException {
+    public String toCedarFormat() throws InternalException, IllegalStateException, NullPointerException {
         if (type == JsonOrCedar.Cedar && schemaText.isPresent()) {
             return schemaText.get();
         } else if (type == JsonOrCedar.Json && schemaJson.isPresent()) {
             return jsonToCedarJni(schemaJson.get().toString());
         } else {
-            throw new IllegalStateException("Schema content is missing");
+            throw new IllegalStateException("No schema found");
         }
     }
 
@@ -147,19 +147,20 @@ public final class Schema {
      *
      * @return JsonNode representing the schema in JSON format
      * @throws InternalException       If conversion from Cedar to JSON format fails
-     * @throws JsonMappingException    If JSON mapping fails
-     * @throws JsonProcessingException If JSON processing fails
      * @throws IllegalStateException   If schema content is missing
-     * @throws NullPointerException    If schema text is null
+     * @throws JsonMappingException    If invalid JSON 
+     * @throws JsonProcessingException If invalid JSON 
+     * @throws NullPointerException
      */
     public JsonNode toJsonFormat()
-            throws InternalException, JsonMappingException, JsonProcessingException, NullPointerException {
+            throws InternalException, JsonMappingException, JsonProcessingException, NullPointerException,
+            IllegalStateException {
         if (type == JsonOrCedar.Json && schemaJson.isPresent()) {
             return schemaJson.get();
         } else if (type == JsonOrCedar.Cedar && schemaText.isPresent()) {
             return OBJECT_MAPPER.readTree(cedarToJsonJni(schemaText.get()));
         } else {
-            throw new IllegalStateException("Schema content is missing");
+            throw new IllegalStateException("No schema found");
         }
     }
 

--- a/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
@@ -130,7 +130,7 @@ public final class Schema {
         } else if (type == JsonOrCedar.Json && schemaJson.isPresent()) {
             return jsonToCedarJni(schemaJson.get().toString());
         } else {
-            throw new InternalException("Schema content is missing");
+            throw new IllegalStateException("Schema content is missing");
         }
     }
 
@@ -145,13 +145,15 @@ public final class Schema {
      */
     public JsonNode toJsonFormat()
             throws InternalException, JsonMappingException, JsonProcessingException, NullPointerException {
-        if (type != JsonOrCedar.Cedar || schemaText.isEmpty()) {
-            throw new InternalException("Schema is not in cedar format");
+        if (type == JsonOrCedar.Json && schemaJson.isPresent()) {
+            return schemaJson.get();
+        } else if (type == JsonOrCedar.Cedar && schemaText.isPresent()) {
+            return OBJECT_MAPPER.readTree(cedarToJsonJni(schemaText.get()));
+        } else {
+            throw new IllegalStateException("Schema content is missing");
         }
-        return OBJECT_MAPPER.readTree(cedarToJsonJni(schemaText.get()));
-
     }
-
+    
     /** Specifies the schema format used. */
     public enum JsonOrCedar {
         /**

--- a/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/schema/Schema.java
@@ -124,6 +124,14 @@ public final class Schema {
 
     }
 
+    /**
+     * Converts a schema to Cedar format
+     *
+     * @return String representing the schema in Cedar format
+     * @throws InternalException     If conversion from JSON to Cedar format fails
+     * @throws IllegalStateException If schema content is missing
+     * @throws NullPointerException  If schema text is null
+     */
     public String toCedarFormat() throws InternalException {
         if (type == JsonOrCedar.Cedar && schemaText.isPresent()) {
             return schemaText.get();
@@ -138,9 +146,10 @@ public final class Schema {
      * Converts a Cedar format schema to JSON format
      *
      * @return JsonNode representing the schema in JSON format
-     * @throws InternalException       If schema is not in Cedar format
+     * @throws InternalException       If conversion from Cedar to JSON format fails
      * @throws JsonMappingException    If JSON mapping fails
      * @throws JsonProcessingException If JSON processing fails
+     * @throws IllegalStateException   If schema content is missing
      * @throws NullPointerException    If schema text is null
      */
     public JsonNode toJsonFormat()
@@ -153,7 +162,7 @@ public final class Schema {
             throw new IllegalStateException("Schema content is missing");
         }
     }
-    
+
     /** Specifies the schema format used. */
     public enum JsonOrCedar {
         /**

--- a/CedarJava/src/test/java/com/cedarpolicy/SchemaTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SchemaTests.java
@@ -146,9 +146,9 @@ public class SchemaTests {
                     """;
             Schema jsonSchemaObj = Schema.parse(JsonOrCedar.Json, jsonSchema);
             String result = jsonSchemaObj.toCedarFormat();
-            
+
             assertNotNull(result, "Result should not be null");
-            assertTrue(result.contains("entity User"), "Converted Cedar should contain the User entity");
+            assertTrue(result.contains("entity User;"), "Converted Cedar should contain the User entity");
         }
 
         @Test
@@ -158,22 +158,23 @@ public class SchemaTests {
             Exception exception = assertThrows(IllegalStateException.class, emptySchema::toCedarFormat);
             assertEquals("Schema content is missing", exception.getMessage());
         }
-        
+
         @Test
         @DisplayName("Should throw exception for malformed JSON schema")
         void testMalformedSchema() {
-            // Missing closing brace in the JSON structure
             String malformedJson = """
                     {
                         "": {
-                            "entityTypes": {
+                            "entityMalformedTypes": {
                                 "User": {}
                             },
-                            "actions": {
+                            "actions": {}
                         }
-                    """; 
+                    }
+                    """;
             Schema malformedSchema = new Schema(JsonOrCedar.Json, Optional.of(malformedJson), Optional.empty());
-            assertThrows(IllegalStateException.class, malformedSchema::toCedarFormat);
+            assertNotNull(malformedSchema.schemaJson);
+            assertThrows(InternalException.class, malformedSchema::toCedarFormat);
         }
     }
 
@@ -187,10 +188,10 @@ public class SchemaTests {
             String cedarSchema = "entity User;";
             Schema cedarSchemaObj = new Schema(cedarSchema);
             JsonNode result = cedarSchemaObj.toJsonFormat();
-            
+
             String expectedJson = "{\"\":{\"entityTypes\":{\"User\":{}},\"actions\":{}}}";
             JsonNode expectedNode = new ObjectMapper().readTree(expectedJson);
-            
+
             assertNotNull(result, "Result should not be null");
             assertEquals(expectedNode, result, "JSON should match expected structure");
         }
@@ -210,10 +211,10 @@ public class SchemaTests {
                     """;
             Schema jsonSchemaObj = Schema.parse(JsonOrCedar.Json, jsonSchema);
             JsonNode result = jsonSchemaObj.toJsonFormat();
-            
+
             ObjectMapper mapper = new ObjectMapper();
             JsonNode expectedNode = mapper.readTree(jsonSchema);
-            
+
             assertNotNull(result, "Result should not be null");
             assertEquals(expectedNode, result, "JSON should match the original schema");
         }
@@ -225,7 +226,7 @@ public class SchemaTests {
             Exception exception = assertThrows(IllegalStateException.class, emptySchema::toJsonFormat);
             assertEquals("Schema content is missing", exception.getMessage());
         }
-        
+
         @Test
         @DisplayName("Should throw exception for malformed Cedar schema")
         void testMalformedSchema() {

--- a/CedarJava/src/test/java/com/cedarpolicy/SchemaTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SchemaTests.java
@@ -156,7 +156,7 @@ public class SchemaTests {
         void testEmptySchema() {
             Schema emptySchema = new Schema(JsonOrCedar.Cedar, Optional.empty(), Optional.empty());
             Exception exception = assertThrows(IllegalStateException.class, emptySchema::toCedarFormat);
-            assertEquals("Schema content is missing", exception.getMessage());
+            assertEquals("No schema found", exception.getMessage());
         }
 
         @Test
@@ -224,7 +224,7 @@ public class SchemaTests {
         void testEmptySchema() {
             Schema emptySchema = new Schema(JsonOrCedar.Cedar, Optional.empty(), Optional.empty());
             Exception exception = assertThrows(IllegalStateException.class, emptySchema::toJsonFormat);
-            assertEquals("Schema content is missing", exception.getMessage());
+            assertEquals("No schema found", exception.getMessage());
         }
 
         @Test

--- a/CedarJava/src/test/java/com/cedarpolicy/SchemaTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/SchemaTests.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -148,7 +147,8 @@ public class SchemaTests {
             String result = jsonSchemaObj.toCedarFormat();
 
             assertNotNull(result, "Result should not be null");
-            assertTrue(result.contains("entity User;"), "Converted Cedar should contain the User entity");
+            String expectedCedar = "entity User;";
+            assertEquals(expectedCedar, result.trim(), "Converted Cedar should match expected format");
         }
 
         @Test

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -15,7 +15,7 @@
  */
 use cedar_policy::entities_errors::EntitiesError;
 #[cfg(feature = "partial-eval")]
- use is_authorized_partial_json_str;
+use cedar_policy::ffi::is_authorized_partial_json_str;
 use cedar_policy::ffi::{
    schema_to_json, schema_to_text, Schema as FFISchema,
     SchemaToJsonAnswer, SchemaToTextAnswer,

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -17,8 +17,7 @@ use cedar_policy::entities_errors::EntitiesError;
 #[cfg(feature = "partial-eval")]
 use cedar_policy::ffi::is_authorized_partial_json_str;
 use cedar_policy::ffi::{
-   schema_to_json, schema_to_text, Schema as FFISchema,
-    SchemaToJsonAnswer, SchemaToTextAnswer,
+    schema_to_json, schema_to_text, Schema as FFISchema, SchemaToJsonAnswer, SchemaToTextAnswer,
 };
 use cedar_policy::{
     ffi::{is_authorized_json_str, validate_json_str},

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -1514,11 +1514,7 @@ pub(crate) mod jvm_based_tests {
             let json_jval = result.unwrap();
             let json_jstr = JString::cast(&mut env, json_jval.l().unwrap()).unwrap();
             let json_str = String::from(env.get_string(&json_jstr).unwrap());
-
-            // Parse the JSON to normalize it for comparison
             let actual_json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
-
-            // Expected JSON structure
             let expected_json = serde_json::json!({
                 "schema": {
                     "entityTypes": {

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -1000,39 +1000,39 @@ pub(crate) mod jvm_based_tests {
         fn from_json_test_valid() {
             let mut env = JVM.attach_current_thread().unwrap();
 
-            let policy_json = r#"
-    {
-        "effect": "permit",
-        "principal": {
-            "op": "==",
-            "entity": { "type": "User", "id": "12UA45" }
-        },
-        "action": {
-            "op": "==",
-            "entity": { "type": "Action", "id": "view" }
-        },
-        "resource": {
-            "op": "in",
-            "entity": { "type": "Folder", "id": "abc" }
-        },
-        "conditions": [
-            {
-                "kind": "when",
-                "body": {
-                    "==": {
-                        "left": {
-                            ".": {
-                                "left": { "Var": "context" },
-                                "attr": "tls_version"
+                        let policy_json = r#"
+                {
+                    "effect": "permit",
+                    "principal": {
+                        "op": "==",
+                        "entity": { "type": "User", "id": "12UA45" }
+                    },
+                    "action": {
+                        "op": "==",
+                        "entity": { "type": "Action", "id": "view" }
+                    },
+                    "resource": {
+                        "op": "in",
+                        "entity": { "type": "Folder", "id": "abc" }
+                    },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": {
+                                "==": {
+                                    "left": {
+                                        ".": {
+                                            "left": { "Var": "context" },
+                                            "attr": "tls_version"
+                                        }
+                                    },
+                                    "right": { "Value": "1.3" }
+                                }
                             }
-                        },
-                        "right": { "Value": "1.3" }
-                    }
+                        }
+                    ]
                 }
-            }
-        ]
-    }
-    "#;
+                "#;
 
             let java_str = env.new_string(policy_json).unwrap();
             let result = from_json_internal(&mut env, java_str);
@@ -1284,24 +1284,24 @@ pub(crate) mod jvm_based_tests {
         fn parse_json_schema_internal_valid_test() {
             let mut env = JVM.attach_current_thread().unwrap();
             let input = r#"{
-    "schema": {
-        "entityTypes": {
-            "User": {
-                "memberOfTypes": ["Group"]
-            },
-            "Group": {},
-            "File": {}
-        },
-        "actions": {
-            "read": {
-                "appliesTo": {
-                    "principalTypes": ["User"],
-                    "resourceTypes": ["File"]
+                "schema": {
+                    "entityTypes": {
+                        "User": {
+                            "memberOfTypes": ["Group"]
+                        },
+                        "Group": {},
+                        "File": {}
+                    },
+                    "actions": {
+                        "read": {
+                            "appliesTo": {
+                                "principalTypes": ["User"],
+                                "resourceTypes": ["File"]
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}"#;
+            }"#;
             let jstr = env.new_string(input).unwrap();
             let result = parse_json_schema_internal(&mut env, jstr);
             assert!(result.is_ok(), "Expected schema to parse successfully");
@@ -1317,24 +1317,24 @@ pub(crate) mod jvm_based_tests {
         fn parse_json_schema_internal_invalid_test() {
             let mut env = JVM.attach_current_thread().unwrap();
             let invalid_input = r#"{
-    "Schema": {
-        "entityTypes": {
-            "User": {
-                "MemberOfTypes": ["Group"]
-            },
-            "Group": {},
-            "File": {}
-        },
-        "Actions": {
-            "read": {
-                "AppliesTo": {
-                    "principalTypes": ["User"],
-                    "AesourceTypes": ["File"]
+                "Schema": {
+                    "entityTypes": {
+                        "User": {
+                            "MemberOfTypes": ["Group"]
+                        },
+                        "Group": {},
+                        "File": {}
+                    },
+                    "Actions": {
+                        "read": {
+                            "AppliesTo": {
+                                "principalTypes": ["User"],
+                                "AesourceTypes": ["File"]
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}"#;
+            }"#;
 
             let jstr = env.new_string(invalid_input).unwrap();
             let result = parse_json_schema_internal(&mut env, jstr);
@@ -1427,24 +1427,24 @@ pub(crate) mod jvm_based_tests {
         fn get_cedar_schema_internal_valid() {
             let mut env = JVM.attach_current_thread().unwrap();
             let json_input = r#"{
-    "schema": {
-        "entityTypes": {
-            "User": {
-                "memberOfTypes": ["Group"]
-            },
-            "Group": {},
-            "File": {}
-        },
-        "actions": {
-            "read": {
-                "appliesTo": {
-                    "principalTypes": ["User"],
-                    "resourceTypes": ["File"]
+                "schema": {
+                    "entityTypes": {
+                        "User": {
+                            "memberOfTypes": ["Group"]
+                        },
+                        "Group": {},
+                        "File": {}
+                    },
+                    "actions": {
+                        "read": {
+                            "appliesTo": {
+                                "principalTypes": ["User"],
+                                "resourceTypes": ["File"]
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}"#;
+            }"#;
 
             let expected_cedar = r#"namespace schema {
             entity File;

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -1000,7 +1000,7 @@ pub(crate) mod jvm_based_tests {
         fn from_json_test_valid() {
             let mut env = JVM.attach_current_thread().unwrap();
 
-                        let policy_json = r#"
+            let policy_json = r#"
                 {
                     "effect": "permit",
                     "principal": {

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -1447,18 +1447,18 @@ pub(crate) mod jvm_based_tests {
 }"#;
 
             let expected_cedar = r#"namespace schema {
-  entity File;
+            entity File;
 
-  entity Group;
+            entity Group;
 
-  entity User in [Group];
+            entity User in [Group];
 
-  action "read" appliesTo {
-    principal: [User],
-    resource: [File],
-    context: {}
-  };
-}"#;
+            action "read" appliesTo {
+                principal: [User],
+                resource: [File],
+                context: {}
+            };
+            }"#;
 
             let jstr = env.new_string(json_input).unwrap();
             let result = get_cedar_schema_internal(&mut env, jstr);
@@ -1506,46 +1506,46 @@ pub(crate) mod jvm_based_tests {
         fn get_json_schema_internal_valid() {
             let mut env = JVM.attach_current_thread().unwrap();
             let cedar_input = r#"
-    namespace schema {
-      entity File;
+            namespace schema {
+            entity File;
 
-      entity Group;
+            entity Group;
 
-      entity User in [Group];
+            entity User in [Group];
 
-      action "read" appliesTo {
-        principal: [User],
-        resource: [File],
-        context: {}
-      };
-    }
-    "#;
+            action "read" appliesTo {
+                principal: [User],
+                resource: [File],
+                context: {}
+            };
+            }
+            "#;
 
             let expected_json = r#"{
-  "schema": {
-    "entityTypes": {
-      "File": {},
-      "Group": {},
-      "User": {
-        "memberOfTypes": [
-          "Group"
-        ]
-      }
-    },
-    "actions": {
-      "read": {
-        "appliesTo": {
-          "resourceTypes": [
-            "File"
-          ],
-          "principalTypes": [
-            "User"
-          ]
-        }
-      }
-    }
-  }
-}"#;
+            "schema": {
+                "entityTypes": {
+                "File": {},
+                "Group": {},
+                "User": {
+                    "memberOfTypes": [
+                    "Group"
+                    ]
+                }
+                },
+                "actions": {
+                "read": {
+                    "appliesTo": {
+                    "resourceTypes": [
+                        "File"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                    }
+                }
+                }
+            }
+            }"#;
 
             let jstr = env.new_string(cedar_input).unwrap();
             let result = get_json_schema_internal(&mut env, jstr);

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -15,8 +15,9 @@
  */
 use cedar_policy::entities_errors::EntitiesError;
 #[cfg(feature = "partial-eval")]
+ use is_authorized_partial_json_str;
 use cedar_policy::ffi::{
-    is_authorized_partial_json_str, schema_to_json, schema_to_text, Schema as FFISchema,
+   schema_to_json, schema_to_text, Schema as FFISchema,
     SchemaToJsonAnswer, SchemaToTextAnswer,
 };
 use cedar_policy::{


### PR DESCRIPTION
This PR introduces new functionality for schema format conversion:

1. Adds two new conversion methods:
   - `.toCedarFormat()`: Converts and returns Schema in Cedar format
   - `.toJsonFormat()`: Converts and returns Schema in JSON format

2. Implements comprehensive test coverage:
   - FFI layer tests to verify native interactions
   - Java unit tests to ensure proper format conversions

Resolves #181 action item for schema conversion