### PR TITLE
adds PolicySet to JSON conversion

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
@@ -113,8 +113,7 @@ public class PolicySet {
       * @throws JsonProcessingException if there is an error serializing the object to JSON
       */
       public String toJson() throws InternalException, JsonProcessingException {
-        String ffiCompatibleJson = objectWriter().writeValueAsString(this);
-        return policySetToJson(ffiCompatibleJson);
+        return policySetToJson(objectWriter().writeValueAsString(this));
     }
 
     /**
@@ -144,5 +143,5 @@ public class PolicySet {
     }
 
     private static native PolicySet parsePoliciesJni(String policiesStr) throws InternalException, NullPointerException;
-    private static native String policySetToJson(String policySetJStr) throws InternalException, NullPointerException;
+    private static native String policySetToJson(String policySetStr) throws InternalException, NullPointerException;
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/model/policy/PolicySet.java
@@ -16,8 +16,10 @@
 
 package com.cedarpolicy.model.policy;
 
+import static com.cedarpolicy.CedarJson.objectWriter;
 import com.cedarpolicy.loader.LibraryLoader;
 import com.cedarpolicy.model.exception.InternalException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.Collections;
 import java.util.List;
@@ -87,20 +89,32 @@ public class PolicySet {
 
     /**
      * Gets number of static policies in the Policy Set.
-     * 
+     *
      * @return number of static policies, returns 0 if policies set is null
      */
     public int getNumPolicies() {
         return policies != null ? policies.size() : 0;
-    } 
+    }
 
     /**
      * Gets number of templates in the Policy Set.
-     * 
+     *
      * @return number of templates, returns 0 if templates set is null
      */
     public int getNumTemplates() {
         return templates != null ? templates.size() : 0;
+    }
+
+    /**
+      * Converts the PolicySet object to a Cedar JSON string representation.
+      *
+      * @return Cedar JSON string representation of the PolicySet
+      * @throws InternalException if there is an error during JSON conversion in the Rust native code
+      * @throws JsonProcessingException if there is an error serializing the object to JSON
+      */
+      public String toJson() throws InternalException, JsonProcessingException {
+        String ffiCompatibleJson = objectWriter().writeValueAsString(this);
+        return policySetToJson(ffiCompatibleJson);
     }
 
     /**
@@ -130,4 +144,5 @@ public class PolicySet {
     }
 
     private static native PolicySet parsePoliciesJni(String policiesStr) throws InternalException, NullPointerException;
+    private static native String policySetToJson(String policySetJStr) throws InternalException, NullPointerException;
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
@@ -43,7 +43,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
@@ -257,9 +256,9 @@ public class JSONTests {
 
     /** Tests deserialization of unknown value */
     @Test
-    public void testDeserializationUnknown() throws JsonProcessingException, IOException {
+    public void testDeserializationUnknown() throws JsonProcessingException {
         String json = "{\"__extn\":{\"fn\":\"unknown\",\"arg\":\"test\"}}";
-        Value value = CedarJson.objectReader().readValue(json, Value.class);
+        Value value = CedarJson.objectMapper().readValue(json, Value.class);
         assertInstanceOf(Unknown.class, value);
         Unknown unknown = (Unknown) value;
         assertEquals("test", unknown.toString());
@@ -267,10 +266,10 @@ public class JSONTests {
 
     /** Tests deserialization of value that causes stack overflow */
     @Test
-    public void testDeserializationStackOverflow() throws IOException {
+    public void testDeserializationStackOverflow() {
         String json = "{\"\":" + "[".repeat(1024) + "]".repeat(1024) + "}";
         try {
-            CedarJson.objectReader().readValue(json, Value.class);
+            CedarJson.objectMapper().readValue(json, Value.class);
         } catch (JsonProcessingException e) {
             System.out.println("class: " + e.getClass());
             assertTrue(e instanceof StreamConstraintsException);

--- a/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/JSONTests.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
@@ -256,9 +257,9 @@ public class JSONTests {
 
     /** Tests deserialization of unknown value */
     @Test
-    public void testDeserializationUnknown() throws JsonProcessingException {
+    public void testDeserializationUnknown() throws JsonProcessingException, IOException {
         String json = "{\"__extn\":{\"fn\":\"unknown\",\"arg\":\"test\"}}";
-        Value value = CedarJson.objectMapper().readValue(json, Value.class);
+        Value value = CedarJson.objectReader().readValue(json, Value.class);
         assertInstanceOf(Unknown.class, value);
         Unknown unknown = (Unknown) value;
         assertEquals("test", unknown.toString());
@@ -266,10 +267,10 @@ public class JSONTests {
 
     /** Tests deserialization of value that causes stack overflow */
     @Test
-    public void testDeserializationStackOverflow() {
+    public void testDeserializationStackOverflow() throws IOException {
         String json = "{\"\":" + "[".repeat(1024) + "]".repeat(1024) + "}";
         try {
-            CedarJson.objectMapper().readValue(json, Value.class);
+            CedarJson.objectReader().readValue(json, Value.class);
         } catch (JsonProcessingException e) {
             System.out.println("class: " + e.getClass());
             assertTrue(e instanceof StreamConstraintsException);

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
@@ -23,10 +23,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.cedarpolicy.TestUtil.buildValidPolicySet;
+import static com.cedarpolicy.TestUtil.buildInvalidPolicySet;
 
 public class PolicySetTests {
     private static final String TEST_RESOURCES_DIR = "src/test/resources/";
@@ -99,5 +102,27 @@ public class PolicySetTests {
         PolicySet policySet = PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "template.cedar"));
         assertEquals(2, policySet.getNumPolicies());
         assertEquals(1, policySet.getNumTemplates());
+    }
+
+    @Test
+    public void policySetToJsonTests() throws JsonProcessingException, IOException, InternalException {
+        // Tests valid PolicySet
+        PolicySet validPolicySet = buildValidPolicySet();
+        String validJson = "{\"templates\":{\"t0\":{\"effect\":\"permit\",\"principal\":{\"op\":\"==\",\"slot\":\"?principal\"},"
+                + "\"action\":{\"op\":\"==\",\"entity\":{\"type\":\"Action\",\"id\":\"View_Photo\"}},"
+                + "\"resource\":{\"op\":\"in\",\"entity\":{\"type\":\"Album\",\"id\":\"Vacation\"}},\"conditions\":[]}},"
+                + "\"staticPolicies\":{\"p1\":{\"effect\":\"permit\",\"principal\":{\"op\":\"==\","
+                + "\"entity\":{\"type\":\"User\",\"id\":\"Bob\"}},"
+                + "\"action\":{\"op\":\"==\",\"entity\":{\"type\":\"Action\",\"id\":\"View_Photo\"}},"
+                + "\"resource\":{\"op\":\"in\",\"entity\":{\"type\":\"Album\",\"id\":\"Vacation\"}},\"conditions\":[]}},"
+                + "\"templateLinks\":[{\"templateId\":\"t0\",\"newId\":\"tl0\",\"values\":{\"?principal\":"
+                + "{\"__entity\":{\"type\":\"User\",\"id\":\"Alice\"}}}}]}";
+        assertEquals(validJson, validPolicySet.toJson());
+        
+        // Tests invalid PolicySet
+        PolicySet invalidPolicySet = buildInvalidPolicySet();
+        assertThrows(InternalException.class, () -> {
+            invalidPolicySet.toJson();
+        });
     }
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/PolicySetTests.java
@@ -36,8 +36,9 @@ public class PolicySetTests {
 
     @Test
     public void parsePoliciesTests() throws InternalException, IOException {
-        PolicySet policySet = PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "policies.cedar"));
-        for (Policy p: policySet.policies) {
+        PolicySet policySet =
+                PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "policies.cedar"));
+        for (Policy p : policySet.policies) {
             assertNotNull(p.policySrc);
         }
         // Make sure the policy IDs are unique as Policies are made
@@ -49,13 +50,14 @@ public class PolicySetTests {
     @Test
     public void parsePoliciesStringTests() throws InternalException {
         PolicySet policySet = PolicySet.parsePolicies("permit(principal, action, resource);");
-        PolicySet policySet2 = PolicySet.parsePolicies("permit(principal, action, resource) when { principal has x && principal.x == 5};");
-        for (Policy p: policySet.policies) {
+        PolicySet policySet2 = PolicySet.parsePolicies(
+                "permit(principal, action, resource) when { principal has x && principal.x == 5};");
+        for (Policy p : policySet.policies) {
             assertNotNull(p.policySrc);
         }
         assertEquals(1, policySet.policies.size());
         assertEquals(0, policySet.templates.size());
-        for (Policy p: policySet2.policies) {
+        for (Policy p : policySet2.policies) {
             assertNotNull(p.policySrc);
         }
         assertEquals(1, policySet2.policies.size());
@@ -64,13 +66,14 @@ public class PolicySetTests {
 
     @Test
     public void parseTemplatesTests() throws InternalException, IOException {
-        PolicySet policySet = PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "template.cedar"));
-        for (Policy p: policySet.policies) {
+        PolicySet policySet =
+                PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "template.cedar"));
+        for (Policy p : policySet.policies) {
             assertNotNull(p.policySrc);
         }
         assertEquals(2, policySet.policies.size());
 
-        for (Policy p: policySet.templates) {
+        for (Policy p : policySet.templates) {
             assertNotNull(p.policySrc);
         }
         assertEquals(1, policySet.templates.size());
@@ -99,26 +102,29 @@ public class PolicySetTests {
         assertEquals(0, emptyPolicySet.getNumTemplates());
 
         // Non-empty policy set
-        PolicySet policySet = PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "template.cedar"));
+        PolicySet policySet =
+                PolicySet.parsePolicies(Path.of(TEST_RESOURCES_DIR + "template.cedar"));
         assertEquals(2, policySet.getNumPolicies());
         assertEquals(1, policySet.getNumTemplates());
     }
 
     @Test
-    public void policySetToJsonTests() throws JsonProcessingException, IOException, InternalException {
+    public void policySetToJsonTests()
+            throws JsonProcessingException, IOException, InternalException {
         // Tests valid PolicySet
         PolicySet validPolicySet = buildValidPolicySet();
-        String validJson = "{\"templates\":{\"t0\":{\"effect\":\"permit\",\"principal\":{\"op\":\"==\",\"slot\":\"?principal\"},"
-                + "\"action\":{\"op\":\"==\",\"entity\":{\"type\":\"Action\",\"id\":\"View_Photo\"}},"
-                + "\"resource\":{\"op\":\"in\",\"entity\":{\"type\":\"Album\",\"id\":\"Vacation\"}},\"conditions\":[]}},"
-                + "\"staticPolicies\":{\"p1\":{\"effect\":\"permit\",\"principal\":{\"op\":\"==\","
-                + "\"entity\":{\"type\":\"User\",\"id\":\"Bob\"}},"
-                + "\"action\":{\"op\":\"==\",\"entity\":{\"type\":\"Action\",\"id\":\"View_Photo\"}},"
-                + "\"resource\":{\"op\":\"in\",\"entity\":{\"type\":\"Album\",\"id\":\"Vacation\"}},\"conditions\":[]}},"
-                + "\"templateLinks\":[{\"templateId\":\"t0\",\"newId\":\"tl0\",\"values\":{\"?principal\":"
-                + "{\"__entity\":{\"type\":\"User\",\"id\":\"Alice\"}}}}]}";
+        String validJson =
+                "{\"templates\":{\"t0\":{\"effect\":\"permit\",\"principal\":{\"op\":\"==\",\"slot\":\"?principal\"},"
+                        + "\"action\":{\"op\":\"==\",\"entity\":{\"type\":\"Action\",\"id\":\"View_Photo\"}},"
+                        + "\"resource\":{\"op\":\"in\",\"entity\":{\"type\":\"Album\",\"id\":\"Vacation\"}},\"conditions\":[]}},"
+                        + "\"staticPolicies\":{\"p1\":{\"effect\":\"permit\",\"principal\":{\"op\":\"==\","
+                        + "\"entity\":{\"type\":\"User\",\"id\":\"Bob\"}},"
+                        + "\"action\":{\"op\":\"==\",\"entity\":{\"type\":\"Action\",\"id\":\"View_Photo\"}},"
+                        + "\"resource\":{\"op\":\"in\",\"entity\":{\"type\":\"Album\",\"id\":\"Vacation\"}},\"conditions\":[]}},"
+                        + "\"templateLinks\":[{\"templateId\":\"t0\",\"newId\":\"tl0\",\"values\":{\"?principal\":"
+                        + "{\"__entity\":{\"type\":\"User\",\"id\":\"Alice\"}}}}]}";
         assertEquals(validJson, validPolicySet.toJson());
-        
+
         // Tests invalid PolicySet
         PolicySet invalidPolicySet = buildInvalidPolicySet();
         assertThrows(InternalException.class, () -> {

--- a/CedarJava/src/test/java/com/cedarpolicy/TestUtil.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/TestUtil.java
@@ -60,7 +60,7 @@ public final class TestUtil {
         EntityTypeName principalType = EntityTypeName.parse("User").get();
         Set<Policy> policies = new HashSet<>();
         Set<Policy> templates = new HashSet<>();
-        ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>(); 
+        ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>();
         ArrayList<LinkValue> linkValueList = new ArrayList<>();
 
         String fullPolicy =
@@ -86,7 +86,7 @@ public final class TestUtil {
         EntityTypeName principalType = EntityTypeName.parse("User").get();
         Set<Policy> policies = new HashSet<>();
         Set<Policy> templates = new HashSet<>();
-        ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>(); 
+        ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>();
         ArrayList<LinkValue> linkValueList = new ArrayList<>();
 
         String fullPolicy =

--- a/CedarJava/src/test/java/com/cedarpolicy/TestUtil.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/TestUtil.java
@@ -18,11 +18,21 @@ package com.cedarpolicy;
 
 import com.cedarpolicy.model.schema.Schema;
 import com.cedarpolicy.model.schema.Schema.JsonOrCedar;
+import com.cedarpolicy.model.policy.TemplateLink;
+import com.cedarpolicy.model.policy.PolicySet;
+import com.cedarpolicy.model.policy.LinkValue;
+import com.cedarpolicy.model.policy.Policy;
+import com.cedarpolicy.model.entity.Entity;
+import com.cedarpolicy.value.EntityTypeName;
 
+import java.util.HashSet;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
 
 /** Utils to help with tests. */
 public final class TestUtil {
@@ -45,4 +55,57 @@ public final class TestUtil {
             throw new RuntimeException("Failed to load test schema file " + schemaFile, e);
         }
     }
+
+    public static PolicySet buildValidPolicySet() {
+        EntityTypeName principalType = EntityTypeName.parse("User").get();
+        Set<Policy> policies = new HashSet<>();
+        Set<Policy> templates = new HashSet<>();
+        ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>(); 
+        ArrayList<LinkValue> linkValueList = new ArrayList<>();
+
+        String fullPolicy =
+                "permit(principal == User::\"Bob\", action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
+        Policy newPolicy = new Policy(fullPolicy, "p1");
+        policies.add(newPolicy);
+
+        String template = "permit(principal == ?principal, action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
+        Policy policyTemplate = new Policy(template, "t0");
+        templates.add(policyTemplate);
+
+        Entity principal = new Entity(principalType.of("Alice"), new HashMap<>(), new HashSet<>());
+        LinkValue principalLinkValue = new LinkValue("?principal", principal.getEUID());
+        linkValueList.add(principalLinkValue);
+
+        TemplateLink templateLink = new TemplateLink("t0", "tl0", linkValueList);
+        templateLinks.add(templateLink);
+
+        return new PolicySet(policies, templates, templateLinks);
+    }
+
+    public static PolicySet buildInvalidPolicySet() {
+        EntityTypeName principalType = EntityTypeName.parse("User").get();
+        Set<Policy> policies = new HashSet<>();
+        Set<Policy> templates = new HashSet<>();
+        ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>(); 
+        ArrayList<LinkValue> linkValueList = new ArrayList<>();
+
+        String fullPolicy =
+                "permit(prinipal == User::\"Bob\", action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
+        Policy newPolicy = new Policy(fullPolicy, "p1");
+        policies.add(newPolicy);
+
+        String template = "permit(principal, action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
+        Policy policyTemplate = new Policy(template, "t0");
+        templates.add(policyTemplate);
+
+        Entity principal = new Entity(principalType.of("Alice"), new HashMap<>(), new HashSet<>());
+        LinkValue principalLinkValue = new LinkValue("?principal", principal.getEUID());
+        linkValueList.add(principalLinkValue);
+
+        TemplateLink templateLink = new TemplateLink("t0", "tl0", linkValueList);
+        templateLinks.add(templateLink);
+
+        return new PolicySet(policies, templates, templateLinks);
+    }
+
 }

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -16,9 +16,9 @@
 use cedar_policy::entities_errors::EntitiesError;
 #[cfg(feature = "partial-eval")]
 use cedar_policy::ffi::is_authorized_partial_json_str;
-use cedar_policy::ffi::PolicySet as PolicySetFFI;
 use cedar_policy::ffi::{
-    schema_to_json, schema_to_text, Schema as FFISchema, SchemaToJsonAnswer, SchemaToTextAnswer,
+    schema_to_json, schema_to_text, PolicySet as PolicySetFFI, Schema as FFISchema,
+    SchemaToJsonAnswer, SchemaToTextAnswer,
 };
 use cedar_policy::{
     ffi::{is_authorized_json_str, validate_json_str},
@@ -1491,7 +1491,7 @@ pub(crate) mod jvm_based_tests {
         fn get_cedar_schema_internal_invalid() {
             let mut env = JVM.attach_current_thread().unwrap();
             let json_input = r#"
-        
+
             entity User = {
                         name: String,
                         age?: Long,

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -16,6 +16,7 @@
 use cedar_policy::entities_errors::EntitiesError;
 #[cfg(feature = "partial-eval")]
 use cedar_policy::ffi::is_authorized_partial_json_str;
+use cedar_policy::ffi::PolicySet as PolicySetFFI;
 use cedar_policy::ffi::{
     schema_to_json, schema_to_text, Schema as FFISchema, SchemaToJsonAnswer, SchemaToTextAnswer,
 };
@@ -267,6 +268,32 @@ fn parse_policy_internal<'a>(
                 Ok(JValueGen::Object(env.new_string(&policy_text)?.into()))
             }
         }
+    }
+}
+
+#[jni_fn("com.cedarpolicy.model.policy.PolicySet")]
+pub fn policySetToJson<'a>(mut env: JNIEnv<'a>, _: JClass, policies_jstr: JString<'a>) -> jvalue {
+    match policy_set_to_json_internal(&mut env, policies_jstr) {
+        Err(e) => jni_failed(&mut env, e.as_ref()),
+        Ok(policies_set) => policies_set.as_jni(),
+    }
+}
+
+fn policy_set_to_json_internal<'a>(
+    env: &mut JNIEnv<'a>,
+    policy_set_jstr: JString<'a>,
+) -> Result<JValueOwned<'a>> {
+    if policy_set_jstr.is_null() {
+        raise_npe(env)
+    } else {
+        let policy_set_jstring = env.get_string(&policy_set_jstr)?;
+        let policy_set_string = String::from(policy_set_jstring);
+        let policy_set_ffi: PolicySetFFI = serde_json::from_str(&policy_set_string)?;
+        let policy_set = policy_set_ffi
+            .parse()
+            .map_err(|err| format!("Error parsing policy set: {:?}", err))?;
+        let policy_set_json = serde_json::to_string(&policy_set.to_json().unwrap())?;
+        Ok(JValueGen::Object(env.new_string(&policy_set_json)?.into()))
     }
 }
 

--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -1618,7 +1618,7 @@ pub(crate) mod jvm_based_tests {
         #[test]
         fn policyset_to_json_valid_test() {
             let mut env = JVM.attach_current_thread().unwrap();
-            let policy_set_str = r#"{
+            let policyset_str = r#"{
                 "staticPolicies": {
                     "p1": "permit(principal == User::\"Bob\", action == Action::\"View_Photo\", resource in Album::\"Vacation\");"
                 },
@@ -1634,14 +1634,14 @@ pub(crate) mod jvm_based_tests {
                 }]
             }"#;
 
-            let policy_set_jstr = env.new_string(policy_set_str).unwrap();
-            let policy_set_json_result = policy_set_to_json_internal(&mut env, policy_set_jstr);
+            let policyset_jstr = env.new_string(policyset_str).unwrap();
+            let policyset_json_result = policy_set_to_json_internal(&mut env, policyset_jstr);
 
-            assert!(policy_set_json_result.is_ok());
+            assert!(policyset_json_result.is_ok());
 
-            let policy_set_json_jstr =
-                JString::cast(&mut env, policy_set_json_result.unwrap().l().unwrap()).unwrap();
-            let actual_json_str = String::from(env.get_string(&policy_set_json_jstr).unwrap());
+            let policyset_json_jstr =
+                JString::cast(&mut env, policyset_json_result.unwrap().l().unwrap()).unwrap();
+            let actual_json_str = String::from(env.get_string(&policyset_json_jstr).unwrap());
 
             let expected_json = serde_json::json!({
                 "templates": {
@@ -1721,7 +1721,7 @@ pub(crate) mod jvm_based_tests {
         #[test]
         fn policyset_to_json_invalid_test() {
             let mut env = JVM.attach_current_thread().unwrap();
-            let policy_set_str = r#"{
+            let policyset_str = r#"{
                 "staticPolicies": {
                     "p1": "permit(principal == User::\"Bob\", act == Action::\"View_Photo\", resrce in Album::\"Vacation\");"
                 },
@@ -1731,11 +1731,11 @@ pub(crate) mod jvm_based_tests {
                 }
             }"#;
 
-            let policy_set_jstr = env.new_string(policy_set_str).unwrap();
-            let policy_set_json_result = policy_set_to_json_internal(&mut env, policy_set_jstr);
+            let policyset_jstr = env.new_string(policyset_str).unwrap();
+            let policyset_json_result = policy_set_to_json_internal(&mut env, policyset_jstr);
 
             assert!(
-                policy_set_json_result.is_err(),
+                policyset_json_result.is_err(),
                 "Expected error when converting a malformed policy set"
             );
 

--- a/CedarJavaFFI/src/jlist.rs
+++ b/CedarJavaFFI/src/jlist.rs
@@ -168,6 +168,7 @@ mod jlist_tests {
 
         let result = list.get(&mut env, 1);
         assert!(result.is_err());
+        env.exception_clear().unwrap();
     }
 
     #[test]
@@ -247,6 +248,7 @@ mod jlist_tests {
             Ok(_) => panic!("Expected error, but got Ok"),
         };
         assert!(result.is_err());
+        env.exception_clear().unwrap();
     }
     #[test]
     fn size_method_works() {


### PR DESCRIPTION
## Overview
Implements JSON conversion support for CedarJava, allowing PolicySet objects to be converted to Cedar's JSON format, similar to the `to_json()` functionality in the [cedar_policy Rust library](https://docs.rs/cedar-policy/latest/cedar_policy/struct.PolicySet.html#method.to_json).


## Changes
- Adds `.toJson` method for `PolicySet` to convert PolicySet to Cedar JSON format 
- Adds tests for both Java and FFI
- Improves test output clarity by adding `env.exception_clear().unwrap()`

## Example Usage
```java
EntityTypeName principalType = EntityTypeName.parse("User").get();
Set<Policy> policies = new HashSet<>();
Set<Policy> templates = new HashSet<>();
ArrayList<TemplateLink> templateLinks = new ArrayList<TemplateLink>();
ArrayList<LinkValue> linkValueList = new ArrayList<>();

String fullPolicy =
        "permit(principal == User::\"Bob\", action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
Policy newPolicy = new Policy(fullPolicy, "p1");
policies.add(newPolicy);

String template = "permit(principal == ?principal, action == Action::\"View_Photo\", resource in Album::\"Vacation\");";
Policy policyTemplate = new Policy(template, "t0");
templates.add(policyTemplate);

Entity principal = new Entity(principalType.of("Alice"), new HashMap<>(), new HashSet<>());
LinkValue principalLinkValue = new LinkValue("?principal", principal.getEUID());
linkValueList.add(principalLinkValue);

TemplateLink templateLink = new TemplateLink("t0", "tl0", linkValueList);
templateLinks.add(templateLink);

PolicySet validPolicySet = PolicySet(policies, templates, templateLinks)

String validPolicySetJson = validPolicySet.toJson()
```



