### PR TITLE
Upgrade Gradle from 8.6 to 8.14.3 and dependencies

### DIFF
--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -76,19 +76,23 @@ configurations {
 }
 
 dependencies {
+    def junitVersion = '6.0.0'
+
     // Do not upgrade to Jackson 3.x without addressing stack overflow issues in ValueDeserializer
     // The upgrade should be reviewed by AppSec
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2'
-    implementation 'com.fizzed:jne:4.3.0'
-    implementation 'com.google.guava:guava:33.4.0-jre'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.6'
-    compileOnly 'org.projectlombok:lombok:1.18.30'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
-    testImplementation 'net.jqwik:jqwik:1.9.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.20.0'
+    implementation 'com.fizzed:jne:4.5.3'
+    implementation 'com.google.guava:guava:33.5.0-jre'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.9.7'
+    compileOnly 'org.projectlombok:lombok:1.18.42'
+    annotationProcessor 'org.projectlombok:lombok:1.18.42'
+    testImplementation 'net.jqwik:jqwik:1.9.3'
     testImplementation 'org.skyscreamer:jsonassert:2.0-rc1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junitVersion}"
 }
 
 def ffiDir = '../CedarJavaFFI'

--- a/CedarJava/gradle/wrapper/gradle-wrapper.properties
+++ b/CedarJava/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

This pull request upgrades the wrapped Gradle version from 8.6 to 8.14.3. There are several deprecation issues that need to be addressed prior to upgrading to Gradle 9.

Additional changes include upgrading dependencies to the latest incremental versions.

- Upgraded JUnit from 5.11.4 to 6.0.0
- Upgraded Jackson from 2.18.2 to 2.20.0
- Upgraded JNE from 4.3.0 to 4.5.3
- Upgraded SpotBugs Annotations from 4.8.6 to 4.9.7
- Upgraded Guava from 33.4.0 to 33.5.0
- Upgraded Lombok from 1.18.30 to 1.18.42
- Upgraded Jqwik from 1.9.2 to 1.9.3