### PR TITLE
Updates Publishing URL and Documentation

### DIFF
--- a/CedarJava/DIFFERENCES_FROM_RUST.md
+++ b/CedarJava/DIFFERENCES_FROM_RUST.md
@@ -1,5 +1,0 @@
-# Differences from Rust
-CedarJava typically lags behind the latest Rust features. Notably, it is currently missing:
-
-- Partial Evaluation
-- Annotations

--- a/CedarJava/README.md
+++ b/CedarJava/README.md
@@ -31,8 +31,26 @@ syntax:
 Debugging calls across the JNI boundary is a bit tricky (as ever a bit more so on a Mac), but can be done by attaching
 both a Java and native debugger (such as GDB/LLDB) to the program.
 
-## Unsupported Features
-You can see a list of features not yet supported in CedarJava at [Differences from Rust](DIFFERENCES_FROM_RUST.md).
+## Windows Support
+
+Windows is not officially supported, but you can build CedarJava manually for Windows targets using the following workaround:
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/cedar-policy/cedar-java
+   cd cedar-java/CedarJavaFFI
+   ```
+
+2. Build the native library for your target ABI:
+   ```bash
+   # For GNU ABI (MinGW)
+   cargo build --features partial-eval --release --target x86_64-pc-windows-gnu
+
+   # For MSVC ABI (Visual Studio)
+   cargo build --features partial-eval --release --target x86_64-pc-windows-msvc
+   ```
+
+3. Set the `CEDAR_JAVA_FFI_LIB` environment variable to point to the generated DLL.
 
 ## Security
 

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -322,7 +322,7 @@ publishing {
     }
     repositories {
         maven {
-            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
             // To publish, uncomment these lines and ensure you have them set in `gradle.properties`
             // credentials {
             //     username ossrhUsername


### PR DESCRIPTION
This PR:
- Replaces the publish API URL from `https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/` to `https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/` as Nexus repository has reached EOL. Instructions for migration [here](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#getting-started-for-maven-api-like-plugins).
- Removes `DIFFERENCES_FROM_RUST.md` as it is not maintained and is difficult to keep up-to-date.
- Adds Windows support section in the README as it was requested by users.


