### PR TITLE
Upgrade zigbuild

### DIFF
--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -127,7 +127,7 @@ tasks.register('installCargoZigbuild', Exec) {
     group 'Build'
     description 'Installs Cargo Zigbuild for Rust compilation.'
 
-    commandLine 'cargo', '+' + RustVersion, 'install', 'cargo-zigbuild@0.19.7'
+    commandLine 'cargo', '+' + RustVersion, 'install', 'cargo-zigbuild@0.22.1'
 }
 
 def ZigVersion = '0.11'


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The "Nightly Build Downstream Dependencies" workflow on the Cedar repository [has been failing since 02/17](https://github.com/cedar-policy/cedar/actions/runs/22330410572/job/64611177957). One of the failures is:
```
   Compiling windows-sys v0.61.2
error: Error calling dlltool 'x86_64-w64-mingw32-dlltool': No such file or directory (os error 2)
```
This issue appears to be fixed by upgrading [zigbuild to bring in this change](https://github.com/rust-cross/cargo-zigbuild/pull/388).

