### PR TITLE
Fix entity parent deserialization for explicit __entity escapes

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/EntityDeserializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/EntityDeserializer.java
@@ -124,12 +124,32 @@ public class EntityDeserializer extends JsonDeserializer<Entity> {
      */
     private EntityUID parseEntityUID(JsonParser parser, JsonNode entityUIDJson)
             throws InvalidValueDeserializationException {
-        if (entityUIDJson.has("type") && entityUIDJson.has("id")) {
-            JsonEUID jsonEuid = new JsonEUID(entityUIDJson.get("type").asText(), entityUIDJson.get("id").asText());
+        JsonNode normalizedEntityUIDJson = entityUIDJson;
+        if (entityUIDJson.has("__entity")) {
+            JsonNode explicitEntityNode = entityUIDJson.get("__entity");
+            if (!explicitEntityNode.isObject()) {
+                String msg = "\"__entity\" must be a JSON object";
+                throw new InvalidValueDeserializationException(
+                        parser,
+                        msg,
+                        explicitEntityNode.asToken(),
+                        Entity.class);
+            }
+            normalizedEntityUIDJson = explicitEntityNode;
+        }
+
+        if (normalizedEntityUIDJson.has("type") && normalizedEntityUIDJson.has("id")) {
+            JsonEUID jsonEuid = new JsonEUID(
+                    normalizedEntityUIDJson.get("type").asText(),
+                    normalizedEntityUIDJson.get("id").asText());
             return EntityUID.parseFromJson(jsonEuid).get();
         } else {
             String msg = "\"type\" or \"id\" not found";
-            throw new InvalidValueDeserializationException(parser, msg, entityUIDJson.asToken(), Entity.class);
+            throw new InvalidValueDeserializationException(
+                    parser,
+                    msg,
+                    normalizedEntityUIDJson.asToken(),
+                    Entity.class);
         }
     }
 

--- a/CedarJava/src/test/java/com/cedarpolicy/EntitiesTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntitiesTests.java
@@ -31,6 +31,7 @@ import org.skyscreamer.jsonassert.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -130,6 +131,41 @@ public class EntitiesTests {
                 + "\"parents\":[{\"type\":\"Photo\",\"id\":\"pic02\"}]," + "\"tags\":{}}]}";
 
         JSONAssert.assertEquals(expectedRepresentation, actualRepresentation, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void givenExplicitEntityParentSyntaxParseReturns() throws JsonProcessingException, IOException {
+        String validEntitiesJson = """
+                [
+                    {"uid":{"type":"Photo","id":"pic01"},
+                    "parents":[{"__entity":{"type":"Photo","id":"pic02"}}],
+                    "attrs":{}},
+                    {"uid":{"type":"Photo","id":"pic02"},"parents":[],"attrs":{}}
+                ]
+                """;
+
+        EntityUID childEUID = EntityUID.parse("Photo::\"pic01\"").get();
+        EntityUID parentEUID = EntityUID.parse("Photo::\"pic02\"").get();
+
+        Entities entitiesFromString = Entities.parse(validEntitiesJson);
+        Entity childFromString = entitiesFromString.getEntities().stream()
+                .filter(entity -> entity.getEUID().equals(childEUID))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(Set.of(parentEUID), childFromString.getParents());
+
+        Path tempFile = Files.createTempFile("entities-explicit-parent", ".json");
+        try {
+            Files.writeString(tempFile, validEntitiesJson);
+            Entities entitiesFromFile = Entities.parse(tempFile);
+            Entity childFromFile = entitiesFromFile.getEntities().stream()
+                    .filter(entity -> entity.getEUID().equals(childEUID))
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals(Set.of(parentEUID), childFromFile.getParents());
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
#347

*Description of changes:*
`Entities.parse(...)` accepted implicit entity UID objects in `parents`, but rejected the equivalent explicit `{"__entity": {"type": "...", "id": "..."}}` form that Cedar JSON already supports elsewhere. This PR unwraps explicit `__entity` escapes when deserializing entity UIDs so parent lists accept both forms consistently.

The PR also adds regression coverage for both `Entities.parse(String)` and `Entities.parse(Path)` to make sure the file-based repro from the issue stays fixed.

Validation:
- Built `CedarJavaFFI` for the host platform with `cargo +1.89 build --release --features partial-eval`
- Ran `CEDAR_JAVA_FFI_LIB=/home/sarthak/cedar-policy-audit/cedar-java/CedarJavaFFI/target/release/libcedar_java_ffi.so ./gradlew test --tests com.cedarpolicy.EntitiesTests -x compileFFI -x extractIntegrationTests -x extractCorpusTests --no-daemon`