### PR TITLE
Improve toCedarExpr() correctness and add CedarStrings utility

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/serializer/ValueSerializer.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/serializer/ValueSerializer.java
@@ -72,7 +72,13 @@ public class ValueSerializer extends JsonSerializer<Value> {
         } else if (value instanceof CedarMap) {
             jsonGenerator.writeStartObject();
             for (Map.Entry<String, Value> entry : ((CedarMap) value).entrySet()) {
-                jsonGenerator.writeObjectField(entry.getKey(), entry.getValue());
+                String key = entry.getKey();
+                if (ENTITY_ESCAPE_SEQ.equals(key) || EXTENSION_ESCAPE_SEQ.equals(key)) {
+                    throw new InvalidValueSerializationException(
+                            "CedarMap key \"" + key + "\" is reserved by the Cedar JSON protocol"
+                                    + " and cannot be used as a record key.");
+                }
+                jsonGenerator.writeObjectField(key, entry.getValue());
             }
             jsonGenerator.writeEndObject();
         } else if (value instanceof IpAddress) {

--- a/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
@@ -66,7 +66,7 @@ public final class CedarMap extends Value implements Map<String, Value> {
     public String toCedarExpr() {
         return "{"
                 + map.entrySet().stream()
-                        .map(e -> '\"' + e.getKey() + "\": " + e.getValue().toCedarExpr())
+                        .map(e -> '\"' + PrimString.escapeCedarString(e.getKey()) + "\": " + e.getValue().toCedarExpr())
                         .collect(Collectors.joining(", "))
                 + "}";
     }

--- a/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
@@ -25,6 +25,10 @@ import java.util.stream.Collectors;
 
 /** Represents a Cedar Map value. Maps support mapping strings to arbitrary values. */
 public final class CedarMap extends Value implements Map<String, Value> {
+    /** Reserved keys in the Cedar JSON protocol that cannot be used as record keys. */
+    private static final String ENTITY_ESCAPE_SEQ = "__entity";
+    private static final String EXTENSION_ESCAPE_SEQ = "__extn";
+
     /** Internal map data. */
     private final java.util.Map<String, Value> map;
 
@@ -35,7 +39,7 @@ public final class CedarMap extends Value implements Map<String, Value> {
      */
     public CedarMap(java.util.Map<String, Value> source) {
         for (String key : source.keySet()) {
-            if ("__entity".equals(key) || "__extn".equals(key)) {
+            if (ENTITY_ESCAPE_SEQ.equals(key) || EXTENSION_ESCAPE_SEQ.equals(key)) {
                 throw new IllegalArgumentException(
                         "Key \"" + key + "\" is reserved by the Cedar JSON protocol"
                                 + " and cannot be used as a record key.");
@@ -73,7 +77,7 @@ public final class CedarMap extends Value implements Map<String, Value> {
     public String toCedarExpr() {
         return "{"
                 + map.entrySet().stream()
-                        .map(e -> '\"' + PrimString.escapeCedarString(e.getKey()) + "\": " + e.getValue().toCedarExpr())
+                        .map(e -> '\"' + CedarStrings.escape(e.getKey()) + "\": " + e.getValue().toCedarExpr())
                         .collect(Collectors.joining(", "))
                 + "}";
     }
@@ -116,10 +120,6 @@ public final class CedarMap extends Value implements Map<String, Value> {
     public Set<String> keySet() {
         return map.keySet();
     }
-
-    /** Reserved keys in the Cedar JSON protocol that cannot be used as record keys. */
-    private static final String ENTITY_ESCAPE_SEQ = "__entity";
-    private static final String EXTENSION_ESCAPE_SEQ = "__extn";
 
     @Override
     public Value put(String k, Value v) throws NullPointerException {

--- a/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/CedarMap.java
@@ -34,6 +34,13 @@ public final class CedarMap extends Value implements Map<String, Value> {
      * @param source map to copy from
      */
     public CedarMap(java.util.Map<String, Value> source) {
+        for (String key : source.keySet()) {
+            if ("__entity".equals(key) || "__extn".equals(key)) {
+                throw new IllegalArgumentException(
+                        "Key \"" + key + "\" is reserved by the Cedar JSON protocol"
+                                + " and cannot be used as a record key.");
+            }
+        }
         this.map = new HashMap<>(source);
     }
 
@@ -110,6 +117,10 @@ public final class CedarMap extends Value implements Map<String, Value> {
         return map.keySet();
     }
 
+    /** Reserved keys in the Cedar JSON protocol that cannot be used as record keys. */
+    private static final String ENTITY_ESCAPE_SEQ = "__entity";
+    private static final String EXTENSION_ESCAPE_SEQ = "__extn";
+
     @Override
     public Value put(String k, Value v) throws NullPointerException {
         if (k == null) {
@@ -118,12 +129,24 @@ public final class CedarMap extends Value implements Map<String, Value> {
         if (v == null) {
             throw new NullPointerException("Attempt to put null value in CedarMap");
         }
+        if (ENTITY_ESCAPE_SEQ.equals(k) || EXTENSION_ESCAPE_SEQ.equals(k)) {
+            throw new IllegalArgumentException(
+                    "Key \"" + k + "\" is reserved by the Cedar JSON protocol"
+                            + " and cannot be used as a record key.");
+        }
 
         return map.put(k, v);
     }
 
     @Override
     public void putAll(Map<? extends String, ? extends Value> m) {
+        for (String key : m.keySet()) {
+            if (ENTITY_ESCAPE_SEQ.equals(key) || EXTENSION_ESCAPE_SEQ.equals(key)) {
+                throw new IllegalArgumentException(
+                        "Key \"" + key + "\" is reserved by the Cedar JSON protocol"
+                                + " and cannot be used as a record key.");
+            }
+        }
         map.putAll(m);
     }
 

--- a/CedarJava/src/main/java/com/cedarpolicy/value/CedarStrings.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/CedarStrings.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cedarpolicy.value;
+
+/**
+ * Utility methods for working with Cedar string literals.
+ */
+public final class CedarStrings {
+
+    private CedarStrings() { }
+
+    /**
+     * Escape a string for safe inclusion in Cedar source code as a string literal.
+     * Handles backslashes, double quotes, and control characters recognized by Cedar.
+     *
+     * @param s the raw string value
+     * @return the escaped string (without surrounding quotes)
+     */
+    public static String escape(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '\0':
+                    sb.append("\\0");
+                    break;
+                default:
+                    sb.append(c);
+                    break;
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/CedarJava/src/main/java/com/cedarpolicy/value/PrimString.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/PrimString.java
@@ -60,41 +60,6 @@ public final class PrimString extends Value {
     /** To Cedar expr that can be used in a Cedar policy. */
     @Override
     public String toCedarExpr() {
-        return "\"" + escapeCedarString(value) + "\"";
-    }
-
-    /**
-     * Escape a string for use in Cedar source code. Escapes backslashes, double quotes,
-     * and control characters that Cedar recognizes as escape sequences.
-     */
-    static String escapeCedarString(String s) {
-        StringBuilder sb = new StringBuilder(s.length());
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            switch (c) {
-                case '\\':
-                    sb.append("\\\\");
-                    break;
-                case '"':
-                    sb.append("\\\"");
-                    break;
-                case '\n':
-                    sb.append("\\n");
-                    break;
-                case '\r':
-                    sb.append("\\r");
-                    break;
-                case '\t':
-                    sb.append("\\t");
-                    break;
-                case '\0':
-                    sb.append("\\0");
-                    break;
-                default:
-                    sb.append(c);
-                    break;
-            }
-        }
-        return sb.toString();
+        return "\"" + CedarStrings.escape(value) + "\"";
     }
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/value/PrimString.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/PrimString.java
@@ -60,6 +60,41 @@ public final class PrimString extends Value {
     /** To Cedar expr that can be used in a Cedar policy. */
     @Override
     public String toCedarExpr() {
-        return "\"" + value + "\"";
+        return "\"" + escapeCedarString(value) + "\"";
+    }
+
+    /**
+     * Escape a string for use in Cedar source code. Escapes backslashes, double quotes,
+     * and control characters that Cedar recognizes as escape sequences.
+     */
+    static String escapeCedarString(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '\0':
+                    sb.append("\\0");
+                    break;
+                default:
+                    sb.append(c);
+                    break;
+            }
+        }
+        return sb.toString();
     }
 }

--- a/CedarJava/src/main/java/com/cedarpolicy/value/Unknown.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/Unknown.java
@@ -49,7 +49,7 @@ public class Unknown extends Value {
      */
     @Override
     public String toCedarExpr() {
-        return "Unknown(\"" + arg + "\")";
+        return "Unknown(\"" + PrimString.escapeCedarString(arg) + "\")";
     }
 
     /**

--- a/CedarJava/src/main/java/com/cedarpolicy/value/Unknown.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/Unknown.java
@@ -49,7 +49,7 @@ public class Unknown extends Value {
      */
     @Override
     public String toCedarExpr() {
-        return "Unknown(\"" + PrimString.escapeCedarString(arg) + "\")";
+        return "Unknown(\"" + CedarStrings.escape(arg) + "\")";
     }
 
     /**

--- a/CedarJava/src/test/java/com/cedarpolicy/CedarExprEscapingTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/CedarExprEscapingTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cedarpolicy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.cedarpolicy.value.CedarMap;
+import com.cedarpolicy.value.PrimString;
+import com.cedarpolicy.value.Unknown;
+import com.cedarpolicy.value.Value;
+
+public class CedarExprEscapingTests {
+
+    @Test
+    public void testPrimStringEscapesDoubleQuotes() {
+        PrimString s = new PrimString("x\" && false && \"x");
+        assertEquals("\"x\\\" && false && \\\"x\"", s.toCedarExpr());
+    }
+
+    @Test
+    public void testPrimStringEscapesBackslash() {
+        PrimString s = new PrimString("path\\to\\file");
+        assertEquals("\"path\\\\to\\\\file\"", s.toCedarExpr());
+    }
+
+    @Test
+    public void testPrimStringEscapesControlCharacters() {
+        PrimString s = new PrimString("line1\nline2\ttab\r\0");
+        assertEquals("\"line1\\nline2\\ttab\\r\\0\"", s.toCedarExpr());
+    }
+
+    @Test
+    public void testPrimStringPlainStringUnchanged() {
+        PrimString s = new PrimString("hello world");
+        assertEquals("\"hello world\"", s.toCedarExpr());
+    }
+
+    @Test
+    public void testPrimStringEmptyString() {
+        PrimString s = new PrimString("");
+        assertEquals("\"\"", s.toCedarExpr());
+    }
+
+    @Test
+    public void testCedarMapEscapesKeys() {
+        Map<String, Value> source = new HashMap<>();
+        source.put("key\"injection", new PrimString("value"));
+        CedarMap map = new CedarMap(source);
+        String expr = map.toCedarExpr();
+        assertTrue(expr.contains("key\\\"injection"));
+        assertFalse(expr.contains("key\"injection"));
+    }
+
+    @Test
+    public void testUnknownEscapesArg() {
+        Unknown u = new Unknown("arg\"injection");
+        assertEquals("Unknown(\"arg\\\"injection\")", u.toCedarExpr());
+    }
+}

--- a/CedarJava/src/test/java/com/cedarpolicy/CedarMapReservedKeyTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/CedarMapReservedKeyTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cedarpolicy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.cedarpolicy.value.CedarMap;
+import com.cedarpolicy.value.PrimString;
+import com.cedarpolicy.value.Value;
+
+public class CedarMapReservedKeyTests {
+
+    @Test
+    public void testPutRejectsEntityKey() {
+        CedarMap map = new CedarMap();
+        assertThrows(IllegalArgumentException.class, () -> {
+            map.put("__entity", new PrimString("spoofed"));
+        });
+    }
+
+    @Test
+    public void testPutRejectsExtnKey() {
+        CedarMap map = new CedarMap();
+        assertThrows(IllegalArgumentException.class, () -> {
+            map.put("__extn", new PrimString("spoofed"));
+        });
+    }
+
+    @Test
+    public void testConstructorRejectsEntityKey() {
+        Map<String, Value> source = new HashMap<>();
+        source.put("__entity", new PrimString("spoofed"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CedarMap(source);
+        });
+    }
+
+    @Test
+    public void testConstructorRejectsExtnKey() {
+        Map<String, Value> source = new HashMap<>();
+        source.put("__extn", new PrimString("spoofed"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CedarMap(source);
+        });
+    }
+
+    @Test
+    public void testPutAllRejectsEntityKey() {
+        CedarMap map = new CedarMap();
+        Map<String, Value> source = new HashMap<>();
+        source.put("safe", new PrimString("ok"));
+        source.put("__entity", new PrimString("spoofed"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            map.putAll(source);
+        });
+    }
+
+    @Test
+    public void testPutAllRejectsExtnKey() {
+        CedarMap map = new CedarMap();
+        Map<String, Value> source = new HashMap<>();
+        source.put("__extn", new PrimString("spoofed"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            map.putAll(source);
+        });
+    }
+
+    @Test
+    public void testNormalKeysStillWork() {
+        CedarMap map = new CedarMap();
+        assertDoesNotThrow(() -> {
+            map.put("entity", new PrimString("ok"));
+            map.put("__other", new PrimString("ok"));
+            map.put("_entity", new PrimString("ok"));
+        });
+    }
+}


### PR DESCRIPTION
## Summary
  - Escape special characters (backslash, quotes, control chars) in `toCedarExpr()` for `PrimString`, `CedarMap` keys, and `Unknown`, aligning behavior with `EntityUID` which already escapes via Rust
  - Validate that `CedarMap` does not accept `__entity`/`__extn` as keys, since these are reserved by the Cedar JSON value protocol and produce malformed payloads
  - Extract escaping into a public `CedarStrings.escape()` utility for integrators building Cedar text

  ## Test plan
  - Added `CedarExprEscapingTests` covering quotes, backslashes, control chars, empty strings, map keys, and Unknown args
  - Added `CedarMapReservedKeyTests` covering put(), putAll(), and constructor
  - Full corpus suite (70,050 tests) passes with no regressions