### PR TITLE
Bugfix: EntityIdentifier equals implementation

### DIFF
--- a/CedarJava/src/main/java/com/cedarpolicy/value/EntityIdentifier.java
+++ b/CedarJava/src/main/java/com/cedarpolicy/value/EntityIdentifier.java
@@ -16,7 +16,6 @@
 
 package com.cedarpolicy.value;
 
-
 import com.cedarpolicy.loader.LibraryLoader;
 
 /**
@@ -24,6 +23,7 @@ import com.cedarpolicy.loader.LibraryLoader;
  * All strings are valid Entity Identifiers
  */
 public final class EntityIdentifier {
+
     private String id;
 
     static {
@@ -54,8 +54,6 @@ public final class EntityIdentifier {
     @Override
     public boolean equals(Object o) {
         if (o == null) {
-            return true;
-        } else if (o == this) {
             return false;
         } else {
             try {
@@ -76,7 +74,5 @@ public final class EntityIdentifier {
         return id;
     }
 
-
     private static native String getEntityIdentifierRepr(EntityIdentifier id);
-
 }

--- a/CedarJava/src/test/java/com/cedarpolicy/EntityIdTests.java
+++ b/CedarJava/src/test/java/com/cedarpolicy/EntityIdTests.java
@@ -16,12 +16,12 @@
 
 package com.cedarpolicy;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.cedarpolicy.value.EntityIdentifier;
-import net.jqwik.api.Property;
-
 import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import org.junit.jupiter.api.Test;
 
 public class EntityIdTests {
 
@@ -32,4 +32,50 @@ public class EntityIdTests {
         assertTrue(asStr.length() >= s.length());
     }
 
+    @Test
+    void equalsSameId() {
+        EntityIdentifier a = new EntityIdentifier("alice");
+        EntityIdentifier b = new EntityIdentifier("alice");
+        assertEquals(a, b);
+    }
+
+    @Test
+    void equalsSameInstance() {
+        EntityIdentifier a = new EntityIdentifier("alice");
+        assertEquals(a, a);
+    }
+
+    @Test
+    void notEqualsDifferentId() {
+        EntityIdentifier a = new EntityIdentifier("alice");
+        EntityIdentifier b = new EntityIdentifier("bob");
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    void notEqualsNull() {
+        EntityIdentifier a = new EntityIdentifier("alice");
+        assertNotEquals(a, null);
+    }
+
+    @Test
+    void notEqualsDifferentType() {
+        EntityIdentifier a = new EntityIdentifier("alice");
+        assertNotEquals(a, "alice");
+    }
+
+    @Test
+    void equalsEmptyStrings() {
+        EntityIdentifier a = new EntityIdentifier("");
+        EntityIdentifier b = new EntityIdentifier("");
+        assertEquals(a, b);
+    }
+
+    @Test
+    void equalsIsSymmetric() {
+        EntityIdentifier a = new EntityIdentifier("test");
+        EntityIdentifier b = new EntityIdentifier("test");
+        assertEquals(a, b);
+        assertEquals(b, a);
+    }
 }


### PR DESCRIPTION
Fixes incorrect `equals` implementation for `EntityIdentifier` and adds tests.




