### PR TITLE
Create CedarJava 4.9 Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
     needs: get-branch-name
     uses: ./.github/workflows/run_cedar_java_reusable.yml
     with:
-      cedar_policy_ref: "refs/heads/main" # use the latest commit on main
+      cedar_policy_ref: ${{ needs.get-branch-name.outputs.branch_name }} # use the same branch of cedar-policy
       cedar_java_ref: "${{ github.href }}" # use the current PR's commit

--- a/CedarJava/CHANGELOG.md
+++ b/CedarJava/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Unreleased
+## 4.9.0
+* Pinned to `cedar-policy 4.9.1`
+* Improve toCedarExpr() correctness and add CedarStrings utility [#351](https://github.com/cedar-policy/cedar-java/pull/351)
+* Add PolicySet and Schema caching [#350](https://github.com/cedar-policy/cedar-java/pull/350)
+* Optimize JNI performance and fix Decimal validation [#349](https://github.com/cedar-policy/cedar-java/pull/349)
+* Updated Java source and target compatibility from 1.8 to 17 aligning with the pre-requisites in README [#350](https://github.com/cedar-policy/cedar-java/pull/350)
+
+## 4.8.0
+* Pinned to `cedar-policy 4.8.2`
 * Added Schema conversion APIs [#325](https://github.com/cedar-policy/cedar-java/pull/325)
 * Added Level Validation [#327](https://github.com/cedar-policy/cedar-java/pull/327)
 * Added DateTime extension support [#328](https://github.com/cedar-policy/cedar-java/pull/328)

--- a/CedarJava/CHANGELOG.md
+++ b/CedarJava/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add PolicySet and Schema caching [#350](https://github.com/cedar-policy/cedar-java/pull/350)
 * Optimize JNI performance and fix Decimal validation [#349](https://github.com/cedar-policy/cedar-java/pull/349)
 * Updated Java source and target compatibility from 1.8 to 17 aligning with the pre-requisites in README [#350](https://github.com/cedar-policy/cedar-java/pull/350)
+* Bugfix: EntityIdentifier equals implementation [#352](https://github.com/cedar-policy/cedar-java/pull/352)
 
 ## 4.8.0
 * Pinned to `cedar-policy 4.8.2`

--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -152,7 +152,7 @@ def ZigVersion = '0.11'
 tasks.register('validateZigVersion') {
     group = 'Build'
     description = 'Validates that the correct zig version is installed'
-    
+
     doLast {
         def output = new ByteArrayOutputStream()
         exec {
@@ -162,7 +162,7 @@ tasks.register('validateZigVersion') {
         def version = output.toString().trim()
         println "Detected Zig version: ${version}"
         if (!version.startsWith(ZigVersion)) {
-            throw new GradleException("Zig version must be ${ZigVersion} but found: ${version}")        
+            throw new GradleException("Zig version must be ${ZigVersion} but found: ${version}")
         }
         println "Zig version validation successful"
     }
@@ -324,7 +324,7 @@ publishing {
             from components.java
             groupId = 'com.cedarpolicy'
             artifactId = 'cedar-java'
-            version = '3.1.2'
+            version = '4.9.0'
 
             artifacts {
                 jar

--- a/CedarJavaFFI/Cargo.toml
+++ b/CedarJavaFFI/Cargo.toml
@@ -6,7 +6,7 @@ description = "Java FFI for Cedar (from the cedar-policy crate)."
 edition = "2021"
 
 
-version = "4.0.0"
+version = "4.9.0"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"] }
@@ -32,11 +32,11 @@ jni = { version = "0.21.1", features = ["invocation"] }
 crate_type = ["cdylib"]
 
 [dependencies.cedar-policy]
-version = "4.0.0"
+version = "4.9.1"
 git = "https://github.com/cedar-policy/cedar"
-branch = "main"
+branch = "release/4.9.x"
 
 [dependencies.cedar-policy-formatter]
-version = "4.0.0"
+version = "4.9.1"
 git = "https://github.com/cedar-policy/cedar"
-branch = "main"
+branch = "release/4.9.x"


### PR DESCRIPTION
* Pinned to `cedar-policy 4.9.1`
* Improve toCedarExpr() correctness and add CedarStrings utility [#351](https://github.com/cedar-policy/cedar-java/pull/351)
* Add PolicySet and Schema caching [#350](https://github.com/cedar-policy/cedar-java/pull/350)
* Optimize JNI performance and fix Decimal validation [#349](https://github.com/cedar-policy/cedar-java/pull/349)
* Updated Java source and target compatibility from 1.8 to 17 aligning with the pre-requisites in README [#350](https://github.com/cedar-policy/cedar-java/pull/350)
* Bugfix: EntityIdentifier equals implementation [#352](https://github.com/cedar-policy/cedar-java/pull/352)

