### PR TITLE
Pins java compatibility to Java 17

### DIFF
--- a/CedarJava/build.gradle
+++ b/CedarJava/build.gradle
@@ -206,6 +206,16 @@ tasks.named('test') {
     classpath += files(layout.buildDirectory.dir(compiledLibDir))
 }
 
+compileTestJava {
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
+}
+
+compileJava {
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
+}
+
 test {
     //environment "CEDAR_INTEGRATION_TESTS_ROOT", ''set to absolute path of `cedar-integration-tests`'
     testLogging {


### PR DESCRIPTION
Pinning source and target compatibility to Java 17 for 3.4 branch. Making it consistent with README and other releases. We have Java 17 pre-req in the readme since the first CedarJava release.
