### PR TITLE
Update security contact.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,7 @@ conduct@cncf.io with any additional questions or comments.
 
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
-
+If you think you have discovered a security issue in this project, **please write to us** at [cedar-policy-security@lists.cncf.io ](mailto:cedar-policy-security@lists.cncf.io ); do **NOT** open a public issue. See our security policy.
 
 ## Licensing
 


### PR DESCRIPTION
This updates the security contact in the contributing guide, to be consistent with https://github.com/cedar-policy/.github/blob/main/CONTRIBUTING.md.


