### PR TITLE
fix(CedarJavaFFI): exhaustive match broken on EntitiesError update

### DIFF
--- a/CedarJavaFFI/src/interface.rs
+++ b/CedarJavaFFI/src/interface.rs
@@ -506,12 +506,16 @@ pub fn validate_entities(input: &str) -> serde_json::Result<Answer> {
 
     match CedarEntities::from_json_value(validate_entity_call.entities, Some(&schema)) {
         Err(error) => {
+            // Unwrap only the variants whose own `Display` impl summarizes instead of
+            // delegating, so the caller keeps the specific inner diagnostic. The rest
+            // are `#[error(transparent)]` or already interpolate their source, so the
+            // catch-all preserves their detail and keeps this compiling when upstream
+            // adds a variant.
             let err_message = match error {
-                EntitiesError::Serialization(err) => err.to_string(),
                 EntitiesError::Deserialization(err) => err.to_string(),
-                EntitiesError::Duplicate(err) => err.to_string(),
                 EntitiesError::TransitiveClosureError(err) => err.to_string(),
                 EntitiesError::InvalidEntity(err) => err.to_string(),
+                err => err.to_string(),
             };
             Ok(Answer::fail_bad_request(vec![err_message]))
         }


### PR DESCRIPTION
# Problem

`validate_entities` in `CedarJavaFFI/src/interface.rs` matches exhaustively on `cedar_policy::entities_errors::EntitiesError`, enumerating all five variants with no wildcard arm. `cedar-policy-core` [4.12.0](https://github.com/cedar-policy/cedar/tree/release/4.12.x) added a sixth variant, `InvalidEntityStructure`, so the crate no longer compiles:

```
error[E0004]: non-exhaustive patterns: `EntitiesError::InvalidEntityStructure(_)` not covered
   --> src/interface.rs:509:37
    |
509 |             let err_message = match error {
    |                                     ^^^^^ pattern `EntitiesError::InvalidEntityStructure(_)` not covered
    |
note: `EntitiesError` defined here
   --> cedar-policy-core-4.12.0/src/entities/err.rs:24:1
    |
24  | pub enum EntitiesError {
    | ^^^^^^^^^^^^^^^^^^^^^^
...
50  |     InvalidEntityStructure(#[from] InvalidEntityStructureError),
    |     ---------------------- not covered

error: could not compile `cedar-java-ffi` (lib) due to 1 previous error
```

`main` is affected because `CedarJavaFFI/Cargo.toml` sources cedar from `branch = "main"`, which now resolves to [4.12.0](https://github.com/cedar-policy/cedar/tree/release/4.12.x). Release branches such as `release/4.10.x` track frozen cedar branches and are unaffected.

Reproduce with a clean clone of `main` (cedar 4.12.0 requires rustc ≥ 1.89):

```
cd CedarJavaFFI && cargo +1.89 check
```

# Fix

Keep explicit arms only for the variants whose own `Display` impl summarizes rather than delegating, and add a catch-all for the rest:

```
let err_message = match error {
    EntitiesError::Deserialization(err) => err.to_string(),
    EntitiesError::TransitiveClosureError(err) => err.to_string(),
    EntitiesError::InvalidEntity(err) => err.to_string(),
    err => err.to_string(),
};
```

Those three carry `#[error("...")]` messages that drop the inner error (`"error during entity deserialization"`, `"transitive closure computation/enforcement error"`, `"entity does not conform to the schema"`), so unwrapping them preserves the specific diagnostic returned to Java callers. Serialization interpolates its source via `{0}`, and `Duplicate` and `InvalidEntityStructure` are `#[error(transparent)]`, so the catch-all loses no detail for them. These attributes are identical in 4.10.0 and 4.12.0.

This keeps the FFI compiling when new variants are added upstream, while retaining the detail the explicit match was there to provide.

# Testing

cargo +1.89 check against cedar-policy-core 4.12.0 (efb14530) — compiles cleanly; the two remaining warnings are pre-existing on main.

# Note for maintainers

`EntitiesError` is publicly re-exported as `cedar_policy::entities_errors::EntitiesError` and is not marked `#[non_exhaustive]`, so adding a variant in 4.12.0 was a breaking change in a minor release. Maybe we should consider marking it `#[non_exhaustive]` in the cedar repo to prevent recurrence for downstream consumers?